### PR TITLE
Sort repos by generation to make links easier to follow

### DIFF
--- a/_data/repos.yml
+++ b/_data/repos.yml
@@ -1,15 +1,38 @@
-- path: Generation 3/Hardware
-  url: https://github.com/floesche/LED-Display_G3_Hardware
-- path: Generation 4/Display_Tools
-  url: https://github.com/JaneliaSciComp/G4_Display_Tools
-- path: Generation 3/Software
-  url: https://github.com/floesche/LED-Display_G3_Software
-- path: Generation 3/Firmware
-  url: https://github.com/floesche/LED-Display_G3_Firmware
-  upstream: https://github.com/iorodeo/panels_g3_firmware
+- path: Generation 2/Arenas
+  url: https://github.com/floesche/LED-Display_G2_Hardware_Arena
+  upstream: https://github.com/iorodeo/panels_arenas
+- path: Generation 2/Hardware
+  url: https://github.com/floesche/LED-Display_G2-G3_Hardware_Panel
+  upstream: https://github.com/iorodeo/panels_g3_hardware
+- path: Generation 2/LED-Arrays
+  url: https://github.com/floesche/LED-Display_G2_Hardware_Driver
+  upstream: https://github.com/iorodeo/panels_led_arrays
 - path: Generation 3/AVRDude
   url: https://github.com/floesche/LED-Display_G3_Firmware_avrdude
   upstream: https://github.com/iorodeo/panels_prog_avrdude
+- path: Generation 3/Breakout-BNC
+  url: https://github.com/floesche/LED-Display_G3_Hardware_Controller_BNC
+  upstream: https://github.com/iorodeo/panels_bnc_breakout
+- path: Generation 3/Breakout-ISP
+  url: https://github.com/floesche/LED-Display_G3_Hardware_Controller_ISP
+  upstream: https://github.com/iorodeo/panels_isp_breakout
+- path: Generation 3/Controller
+  url: https://github.com/floesche/LED-Display_G3_Hardware_Controller
+  upstream: https://github.com/willdickson/panels_controller
+- path: Generation 3/Firmware
+  url: https://github.com/floesche/LED-Display_G3_Firmware
+  upstream: https://github.com/iorodeo/panels_g3_firmware
+- path: Generation 3/Hardware
+  url: https://github.com/floesche/LED-Display_G3_Hardware
+- path: Generation 3/Panelcom
+  url: https://github.com/floesche/LED-Display_G3_Software_Panelcom
+  upstream: https://github.com/iorodeo/panel_comm
+- path: Generation 3/Software
+  url: https://github.com/floesche/LED-Display_G3_Software
+- path: Generation 4/Arena
+  url: https://github.com/floesche/LED-Display_G4_Hardware_Arena
+- path: Generation 4/Display_Tools
+  url: https://github.com/JaneliaSciComp/G4_Display_Tools
 - path: Generation 4/Documentation
   url: https://github.com/floesche/LED-Display_G4_Documentation
   upstream: https://github.com/iorodeo/panels_g4_docs
@@ -19,28 +42,5 @@
 - path: Generation 4/Hardware
   url: https://github.com/floesche/LED-Display_G4_Hardware
   upstream: https://github.com/iorodeo/panels_g4_hardware
-- path: Generation 2/Hardware
-  url: https://github.com/floesche/LED-Display_G2-G3_Hardware_Panel
-  upstream: https://github.com/iorodeo/panels_g3_hardware
-- path: Generation 2/Arenas
-  url: https://github.com/floesche/LED-Display_G2_Hardware_Arena
-  upstream: https://github.com/iorodeo/panels_arenas
-- path: Generation 2/LED-Arrays
-  url: https://github.com/floesche/LED-Display_G2_Hardware_Driver
-  upstream: https://github.com/iorodeo/panels_led_arrays
-- path: Generation 3/Panelcom
-  url: https://github.com/floesche/LED-Display_G3_Software_Panelcom
-  upstream: https://github.com/iorodeo/panel_comm
-- path: Generation 3/Controller
-  url: https://github.com/floesche/LED-Display_G3_Hardware_Controller
-  upstream: https://github.com/willdickson/panels_controller
-- path: Generation 3/Breakout-BNC
-  url: https://github.com/floesche/LED-Display_G3_Hardware_Controller_BNC
-  upstream: https://github.com/iorodeo/panels_bnc_breakout
-- path: Generation 3/Breakout-ISP
-  url: https://github.com/floesche/LED-Display_G3_Hardware_Controller_ISP
-  upstream: https://github.com/iorodeo/panels_isp_breakout
-- path: Generation 4/Arena
-  url: https://github.com/floesche/LED-Display_G4_Hardware_Arena
 - path: Generation 4/Panel
   url: https://github.com/floesche/LED-Display_G4_Hardware_Driver


### PR DESCRIPTION
The random sorting of the repo links on the main documentation page made it a little tricky to quickly find the link I was looking for, so I sorted the repos in repos.yml first by panel generation, then alphabetically.

I assume that the link list automatically generated by index.md in the line {% for repo in site.data.repos %} follows the order of the repos listed in repos.yml.