### PR TITLE
docs(g6 dev): protocol-restructure rollup + paper-trail pruning

### DIFF
--- a/docs/development/g6_00-architecture.md
+++ b/docs/development/g6_00-architecture.md
@@ -47,8 +47,6 @@ The Teensy 4.1 + 2-SPI-bus configuration is concrete for the current production 
 - **Panel firmware** owns the *schematic → physical-pin* mapping: applies the PCB-layout-driven remap (e.g., `display.cpp::sch_to_pos_index()` in `g6_firmware_devel @ 6944894`, with the `NUM_COLOR = 4` quadrant scheme) to convert schematic-pixel index to actual COL/ROW drive pins.
 - The G6 controller sees patterns only as sequences of 20×20 subframes, ordered by panel number already mapped by the host. Controller packs pixels and forwards them per the G6 panel protocol — it does **not** apply LED mapping.
 
-(Note: the source spec mentioned "color-LED organization (until we decide to make the panels 'color-aware' in v4/5)" — current v4 and v5 do not specify color awareness; the parenthetical is dropped, captured in Open Q #1.)
-
 **Host owns arena / panel layout**
 
 - The PC host also defines how multiple panels are arranged in space (arena layout).
@@ -69,7 +67,7 @@ Panel message format is common to all protocol versions and is as specified in t
   - `0x01` (`0b00000001`) — when parity bit = 0
   - `0x81` (`0b10000001`) — when parity bit = 1
 
-More precisely: the **scaffolding is common** (`[header byte][command byte][payload…]` shape, parity-bit-in-MSB convention) and the **version field in the header byte selects which command set applies** (v1 = `0b0000001`, v2 = `0b0000010`, v3 = `0b0000011`, v4 = `0b0000100`). See [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) for the per-version command tables.
+More precisely: the **scaffolding is common** (`[header byte][command byte][payload…]` shape, parity-bit-in-MSB convention) and the **version field in the header byte selects which command set applies** (v1 = `0b0000001` live-SPI display, v2 = `0b0000010` PSRAM-backed display, v3 = `0b0000011` diagnostics + predefined patterns + future feature classes). See [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) for the per-version command tables.
 
 ### Panel responsibilities
 
@@ -81,9 +79,8 @@ The panel receives commands via SPI and returns confirmations according to the [
 
 ## Open Questions / TBDs
 
-1. **Color-LED organization** — original source spec referred to "color-aware in v4/v5", but neither v4 (predefined patterns + stretch) nor v5 (sketch) currently specify color support. Aspirational; revisit when color support is actually specced.
-2. **Stateless-panel vs mode-flag question** (carried over from precursor) — v1's Oneshot-only model is consistent with the stateless approach, but v3's Triggered/Gated commands re-open the question. Defer to firmware investigation against `G6_Panels_Test_Firmware`.
-3. **Architecture-prose tightening** (non-blocking) — minor items: (a) "controller never needs to know spatial layout" is overreach for Mode 4 closed-loop; (b) "Endianess" → "Endianness" typo on §; (c) common-message-format claim should be reworded once g6_01 master command summary has v1–v4 version-bits clearly tabled. Bundle for next pass.
+1. **Color-LED organization** — original source spec referred to "color-aware in v4/v5"; under the post-restructure V1/V2/V3 themes (live SPI / PSRAM / everything-else), color support is part of v3 § Future feature classes. Aspirational; revisit when color support is actually specced.
+2. **Stateless-panel vs mode-flag question.** v1's controller-driven one-shot model (Oneshot, Triggered, Gated all one-shot per command; Persistent the special case) is consistent with the stateless approach. The Triggered/Gated open questions (exact pattern-consumption semantics — see g6_01-panel-protocol.md § `0x12` / `0x13`) need design review before v1 firmware ships those commands.
 
 ## Cross-references
 

--- a/docs/development/g6_01-panel-protocol.md
+++ b/docs/development/g6_01-panel-protocol.md
@@ -58,6 +58,56 @@ The parity bit is set such that this count modulo 2 equals the parity bit value,
 - 2-level oneshot (command `0x10`), all pixels=0, duty_cycle=1 → header should be `0x81` (1 from version + 1 from command + 1 from duty_cycle = 3 ones → parity 1)
 - 16-level oneshot (command `0x30`), all pixels=0, duty_cycle=0 → header should be `0x81` (1 from version + 2 from command = 3 ones → parity 1)
 
+#### CRC-8 algorithm
+
+All single-byte checksums in the G6 protocol family use **CRC-8/AUTOSAR**:
+
+| Parameter | Value |
+| :-- | :-- |
+| Polynomial | `0x2F` (`x^8 + x^5 + x^3 + x^2 + x + 1`; Koopman notation `0x97`) |
+| Initial value | `0xFF` |
+| Input reflection | false |
+| Output reflection | false |
+| Final XOR | `0xFF` |
+| Universal check value | `0xDF` over the ASCII string `"123456789"` |
+
+Three sites use this algorithm:
+
+1. **CIPO panel-confirmation checksum** — third byte of the 3-byte confirmation slot, over `{incoming COPI header_byte_with_parity_cleared, cmd_byte, payload_bytes}` of the message being acknowledged.
+2. **ISP extended-confirmation checksum** — trailing byte of the ISP confirmation slot, over `{outgoing CIPO header_byte_with_parity_cleared, cmd_byte, response_payload}`.
+3. **Pattern-file header checksum** — byte 17 of the `.pat` file header (see [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md) § Header CRC). Scope: header bytes 0-16 only. Frame-data integrity is the job of the per-frame CRC-16 trailer specified in `g6_04` § Frame Format (CRC-16/CCITT, HD=4 across our frame sizes, localizes corruption to a specific frame).
+
+**Detection properties at G6 message sizes:**
+
+- HD=4 (catches all 3-bit errors) for data words up to 119 bits.
+- HD=2 (catches all 1-bit errors) for longer messages, including the 424-bit GS2 payload, 1624-bit GS16 payload, and multi-MB pattern files. The HD=2 regime above 119 bits is the price of the 1-byte budget; some 2-bit errors slip through (~2/256 probability for random 2-bit patterns).
+- Catches all burst errors up to 8 bits long at every message size.
+- Strictly stronger than sum-mod-256 or XOR for burst errors.
+
+**Bit and byte ordering.** SPI is MSB-first on the wire (§ SPI framing). CRC-8/AUTOSAR has `refin=false`, meaning each input byte is fed MSB-first into the LFSR. The two conventions align — the bit stream the CRC processes is the bit stream that hits the wire. **No bit reversal needed.** Bytes are fed in transmission order (byte 0 first). The CRC byte itself is NOT included in the CRC computation.
+
+**Construction order for the 3-byte confirmation slot** (resolves CRC/parity dependency):
+
+1. Compute CRC over `{version_byte_with_parity_bit_cleared, cmd_byte, payload_bytes}` of the message being acknowledged.
+2. Place `{header_byte_template_with_parity_cleared, cmd_byte, crc_byte}` in the confirmation slot.
+3. Compute parity over the resulting 3-byte slot (count 1-bits across all 24 bits except the parity bit) and set the parity bit in the header.
+
+The same procedure applies to the ISP extended-confirmation slot over its longer response payload.
+
+**Sentinel discriminator.** Confirmation-slot sentinels use the cmd byte as the discriminator: `cmd=0x00` for the empty-buffer sentinel and `cmd=0xFF` for the COMM_CHECK-fail sentinel. The CRC byte in those slots is the literal `0x00` (convention: no real payload to checksum), NOT a computed CRC over `{version, sentinel_cmd}`. **Validators MUST branch on the cmd byte before treating byte 2 as a CRC** — a valid message can naturally produce CRC `0x00`, so the checksum value alone cannot distinguish a sentinel from a real message.
+
+**Protocol-specific test vectors** (final values pinned in [`g6_encoding_reference.json`](../../Generation%206/maDisplayTools/g6/g6_encoding_reference.json) once the encoders are regenerated):
+
+| Input bytes (hex) | Description | CRC |
+| :-- | :-- | :-- |
+| `01 10 00…00 00` (53 bytes: hdr + cmd + 50× zero pixels + duty=0) | 2L Oneshot all-zero | `0xC6` |
+| `81 30 00…00 00` (203 bytes: hdr+parity + cmd + 200× zero pixels + duty=0) | 16L Oneshot all-zero | `0x0C` |
+| `01 01 00 01 02 … C7` (202 bytes: COMM_CHECK canonical) | COMM_CHECK | `0x8B` |
+
+Implementers MUST verify their CRC implementation against both the universal `"123456789"` → `0xDF` check value and at least one protocol-specific vector before integration.
+
+**Reference implementations:** Linux kernel `lib/crc8.c`, Boost.CRC, Python `crcmod`. RP2354 implementation can use a 256-byte lookup table in flash; computational cost is negligible at SPI traffic rates.
+
 #### Duty Cycle Value
 
 The `duty_cycle` value is a single byte (0–255) that scales the brightness of all pixels in a pattern by **modulating the BCM bit-plane ON-time durations** (not the pixel values themselves). Effective per-bit-plane ON time = `base_T × duty_cycle / 255`, where `base_T` is the BCM base time (3.0 µs in v1 panel firmware). `duty_cycle = 0` → all bit-planes have zero ON time → display off. `duty_cycle = 255` → unchanged from base BCM weights.
@@ -79,7 +129,7 @@ Each message SHALL be transmitted as exactly one SPI transaction, bounded by chi
 
 **SPI mode**: CPOL=1, CPHA=1 (SPI Mode 3), MSB-first. **Clock**: panels accept up to 30 MHz (firmware default in [`reiserlab/LED-Display_G6_Firmware_Panel/panel/src/constants.cpp`](https://github.com/reiserlab/LED-Display_G6_Firmware_Panel/blob/feat/v1-stage1-protocol/panel/src/constants.cpp)). Cross-platform implementations SHOULD configure the same.
 
-A message from the controller to the panel is defined by the "protocol commands". The panels return the header and command from the previously received message followed by an 8-bit checksum.
+A message from the controller to the panel is defined by the "protocol commands". The panels return the header and command from the previously received message followed by an 8-bit CRC-8 checksum (per § CRC-8 algorithm).
 
 The controller SHALL clock exactly the number of bytes required by the command for that protocol version, but at least 3 bytes. Invalid messages are ignored and don't trigger a panel update.
 
@@ -220,11 +270,13 @@ On CS falling edge, a panel returns a **3-byte confirmation slot** describing th
 [byte 0: header_with_parity]  [byte 1: cmd_or_sentinel]  [byte 2: checksum]
 ```
 
-When the panel receives a valid command, it stores the version (from the incoming header), the command byte, and an 8-bit checksum **over the whole incoming message** (header byte + command byte + payload bytes, sum mod 256). The header byte in the confirmation slot echoes the **incoming protocol version** (`0x01` for V1; in future, `0x02` for V2) with the parity bit **recomputed** over the 3-byte confirmation message.
+When the panel receives a valid command, it stores the version (from the incoming header), the command byte, and an 8-bit CRC-8 checksum (per § CRC-8 algorithm) over the incoming message bytes excluding the CRC byte itself. The header byte in the confirmation slot echoes the **incoming protocol version** (`0x01` for V1; in future, `0x02` for V2) with the parity bit **recomputed** per the construction-order rule in § CRC-8 algorithm.
 
 For invalid commands (parity failure, length mismatch, unsupported protocol version, unknown command, etc.) the buffer is **not updated** — the panel continues to return whatever was in the slot before. This preserves the spec invariant "for invalid commands no information is stored."
 
-The 3-byte slot is **cleared** by the panel only after at least 3 bytes have been clocked out on CIPO. If the controller asserts CS for fewer than 3 byte windows, the slot stays armed for the next CS-active window. (Every valid panel-protocol message is ≥ 3 bytes — header + cmd + ≥ 1 payload byte — so any normal traffic cycle clears the previous confirmation.)
+**Every valid panel-protocol message MUST be at least 3 bytes** (header + cmd + ≥ 1 payload byte). Commands that would otherwise have a zero-byte payload are padded with one reserved byte (`0x0F` Reset PSRAM, `0x02` Query diagnostics, `0x03` Reset diagnostic stats — all carry a 1-byte ignored payload). The minimum-3-byte rule guarantees that every CS-active window clocks out all 3 bytes of the prior confirmation, so confirmations cannot accumulate or be silently dropped between commands.
+
+If a controller violates the ≥ 3 byte rule (e.g., asserts CS for fewer than 3 byte windows after sending a too-short message), the panel rejects the short message on length-check; the prior confirmation slot stays armed and is delivered on the next valid CS-active window.
 
 **4-state encoding** (normative; matches firmware behavior):
 
@@ -237,7 +289,7 @@ The 3-byte slot is **cleared** by the panel only after at least 3 bytes have bee
 
 **`cmd = 0xFF` is reserved panel-side** for the COMM_CHECK-fail sentinel and MUST NOT be issued by a controller. See Master command summary § Reserved confirmation values.
 
-The 8-bit additive checksum (sum mod 256) is faster to compute than CRC/SHA — a single loop over the receive buffer. Matches `Message::calculate_8bit_checksum()` in `reiserlab/LED-Display_G6_Firmware_Panel @ feat/v1-stage1-protocol` ([message.cpp:171–177](https://github.com/reiserlab/LED-Display_G6_Firmware_Panel/blob/feat/v1-stage1-protocol/panel/src/message.cpp#L171-L177)). (Note: the panel-confirmation checksum here is **additive** (sum mod 256); the [pattern-file checksum in `g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md) is **XOR**. Both are confirmed against firmware; the two algorithms intentionally differ.)
+Algorithm details and test vectors in § CRC-8 algorithm above. Note: pattern-file frame integrity uses **CRC-16/CCITT per-frame** (`g6_04` § Frame Format), distinct from this wire-level CRC-8; only the file header at `g6_04` byte 17 shares this CRC-8 algorithm.
 
 **Examples:**
 
@@ -366,9 +418,9 @@ Opcode encoding follows the low-nibble-mode rule (`0`=Oneshot, `1`=Persistent, `
 
 Clears all user-stored patterns from PSRAM (preserves predefined patterns under v3 `0x70`–`0x73`, if those use a separate flash region — see v3).
 
-**Payload**: None (0 bytes)
+**Payload**: 1 byte (reserved; transmit as `0x00`, panel ignores). Padding ensures every message is ≥ 3 bytes so the CIPO confirmation slot drains in each CS-active window (see § Confirmation message).
 
-**Example**: `[0x82] [0x0F]`
+**Example**: `[0x02] [0x0F] [0x00]`
 
 #### `0x3F` — Write 16-Level Grayscale to PSRAM
 
@@ -475,9 +527,9 @@ For Protocol v3, the version bits are `0b0000011`, giving possible header values
 
 Get diagnostics from the panel. Current candidates from `<will@iorodeo.com>`: counts of bad bytes, short messages, parity failures, queue drops, or other error rates. Statistics could be collected from `0x01` COMM_CHECK responses or from all messages since the last reset.
 
-**Payload**: None (0 bytes)
+**Payload**: 1 byte (reserved; transmit as `0x00`, panel ignores). Padding ensures every message is ≥ 3 bytes — see § Confirmation message.
 
-**Example**: `[0x03] [0x02]`
+**Example**: `[0x03] [0x02] [0x00]`
 
 > **⚠ Flag — diagnostic data shape unspecified.** Spec the diagnostic record format (counters, error codes, response carrier slot) before this command becomes implementable. The CIPO confirmation slot is 3 bytes — diagnostic data exceeds that, so a separate response mechanism is needed (extended slot? streamed over CIPO with explicit length? mailbox via PSRAM?).
 
@@ -485,9 +537,9 @@ Get diagnostics from the panel. Current candidates from `<will@iorodeo.com>`: co
 
 Reset the diagnostic counter(s).
 
-**Payload**: None (0 bytes)
+**Payload**: 1 byte (reserved; transmit as `0x00`, panel ignores). Padding ensures every message is ≥ 3 bytes — see § Confirmation message.
 
-**Example**: `[0x83] [0x03]`
+**Example**: `[0x83] [0x03] [0x00]`
 
 #### `0x70` / `0x71` / `0x72` / `0x73` — Display Predefined Pattern (mode in low nibble)
 
@@ -531,13 +583,13 @@ Status: **Draft — design-review needed**. ISP commands live in the v1 namespac
 
 ### ISP confirmation format
 
-ISP messages use an **extended confirmation slot** that adds an opcode-specific response payload between the echoed command and the 8-bit additive checksum. Format on CIPO during the *next* ISP-armed CS-active window:
+ISP messages use an **extended confirmation slot** that adds an opcode-specific response payload between the echoed command and the 8-bit CRC-8 checksum (per § CRC-8 algorithm, including the construction-order rule for the parity bit). Format on CIPO during the *next* ISP-armed CS-active window:
 
 ```
 [header (parity recomputed)] [echoed_cmd] [response_payload_N_bytes] [8-bit checksum]
 ```
 
-where `N` depends on `echoed_cmd` (see opcode table, "Response payload" column). The 8-bit additive checksum covers the entire CIPO message (header + cmd + response_payload). This differs from the standard 3-byte confirmation slot (§ Confirmation message above): standard panel-protocol messages keep the 3-byte form; only ISP opcodes use this extended form.
+where `N` depends on `echoed_cmd` (see opcode table, "Response payload" column). The 8-bit CRC-8 checksum covers the CIPO message bytes excluding the CRC byte itself (header + cmd + response_payload). This differs from the standard 3-byte confirmation slot (§ Confirmation message above): standard panel-protocol messages keep the 3-byte form; only ISP opcodes use this extended form.
 
 For `ISP_ENTER` specifically, the response cannot piggyback on a preceding command (no prior ISP command exists). The controller therefore clocks out exactly `1 + 1 + 17 + 1 = 20` bytes on the SAME `ISP_ENTER` transaction: the panel computes its response during the COPI phase (after parsing payload), then drives MISO during the trailing CIPO byte windows. CS stays asserted for the full 20-byte exchange. All subsequent ISP commands follow the standard "response piggybacks on next ISP command" pattern.
 
@@ -584,7 +636,7 @@ v1 Triggered + Gated are prototyped (Triggered measured at 865 ± 17 ns trigger-
 | `0x01` / `0x81` | `0x13` | 51 bytes (50 pattern + duty_cycle) | Display 2-Level Grayscale (Gated) | v1 | prototyped |
 | `0x01` / `0x81` | `0x32` | 201 bytes (200 pattern + duty_cycle) | Display 16-Level Grayscale (Triggered) | v1 | prototyped |
 | `0x01` / `0x81` | `0x33` | 201 bytes (200 pattern + duty_cycle) | Display 16-Level Grayscale (Gated) | v1 | prototyped |
-| `0x02` / `0x82` | `0x0F` | None | Reset PSRAM (clear user patterns) | v2 | |
+| `0x02` / `0x82` | `0x0F` | 1 byte (reserved) | Reset PSRAM (clear user patterns) | v2 | |
 | `0x02` / `0x82` | `0x3F` | 3 idx + 200 pattern + duty_cycle | Write 16-Level Grayscale to PSRAM | v2 | ⚠ index semantics open |
 | `0x02` / `0x82` | `0x50` | 3 idx | Display PSRAM Index, implicit duty_cycle (Oneshot) | v2 | |
 | `0x02` / `0x82` | `0x51` | 3 idx | Display PSRAM Index, implicit duty_cycle (Persistent) | v2 | |
@@ -594,8 +646,8 @@ v1 Triggered + Gated are prototyped (Triggered measured at 865 ± 17 ns trigger-
 | `0x02` / `0x82` | `0x61` | 3 idx + duty_cycle | Display PSRAM Index, explicit duty_cycle (Persistent) | v2 | |
 | `0x02` / `0x82` | `0x62` | 3 idx + duty_cycle | Display PSRAM Index, explicit duty_cycle (Triggered) | v2 | |
 | `0x02` / `0x82` | `0x63` | 3 idx + duty_cycle | Display PSRAM Index, explicit duty_cycle (Gated) | v2 | |
-| `0x03` / `0x83` | `0x02` | None | Query diagnostic stats | v3 | ⚠ data shape unspecified |
-| `0x03` / `0x83` | `0x03` | None | Reset diagnostic stats | v3 | |
+| `0x03` / `0x83` | `0x02` | 1 byte (reserved) | Query diagnostic stats | v3 | ⚠ data shape unspecified |
+| `0x03` / `0x83` | `0x03` | 1 byte (reserved) | Reset diagnostic stats | v3 | |
 | `0x03` / `0x83` | `0x70` | 3 idx + duty_cycle | Display Predefined Pattern (Oneshot) | v3 | ⚠ pattern catalog TBD |
 | `0x03` / `0x83` | `0x71` | 3 idx + duty_cycle | Display Predefined Pattern (Persistent) | v3 | ⚠ pattern catalog TBD |
 | `0x03` / `0x83` | `0x72` | 3 idx + duty_cycle | Display Predefined Pattern (Triggered) | v3 | ⚠ pattern catalog TBD |
@@ -648,10 +700,9 @@ Modes are encoded in the low nibble of the command byte (`0`=Oneshot, `1`=Persis
 
 ## Open Questions / TBDs
 
-1. **v2 zero-payload commands.** `0x02`, `0x03`, `0x0F` have zero-byte payloads in spec but firmware enforces `PAYLOAD_MINIMUM_SIZE = 1`. Decide during v2 migration: drop the floor or add a dummy byte.
-2. **Worked pixel-mapping example pinned to panel v0.1 hardware.** Per-revision LED designator tables pending KiCad source extraction (see [`g6_02-led-mapping.md`](g6_02-led-mapping.md) Open Q #2).
-3. **Panel error display command-set decision.** Which errors are most relevant and what command code carries them within the `0xC2`/predefined-pattern-0 framework.
-4. **v3 trigger edge polarity** (from test rig). Firmware code expects rising edge but AD3 + Ch2 captures show LED fires on the **falling edge** of W1 — likely hardware ringing (±2.5 V overshoot). Hypothesis in `G6_Panels_Test_Firmware/single_led/SESSION_2026-04-24_PIOFULL_AD3.md`; not yet fixed.
+1. **Worked pixel-mapping example pinned to panel v0.1 hardware.** Per-revision LED designator tables pending KiCad source extraction (see [`g6_02-led-mapping.md`](g6_02-led-mapping.md) Open Q #2).
+2. **Panel error display command-set decision.** Which errors are most relevant and what command code carries them within the `0xC2`/predefined-pattern-0 framework.
+3. **v3 trigger edge polarity** (from test rig). Firmware code expects rising edge but AD3 + Ch2 captures show LED fires on the **falling edge** of W1 — likely hardware ringing (±2.5 V overshoot). Hypothesis in `G6_Panels_Test_Firmware/single_led/SESSION_2026-04-24_PIOFULL_AD3.md`; not yet fixed.
 
 ## Implementation status
 
@@ -659,7 +710,7 @@ v1 panel firmware: [`reiserlab/LED-Display_G6_Firmware_Panel`](https://github.co
 
 | Spec item | Status |
 | :-- | :-- |
-| Message framing, header byte, parity rule, CIPO 3-byte confirmation slot (4-state encoding, `0xFF` COMM_CHECK-fail sentinel) | implemented (not yet stacked-panel bench-validated) |
+| Message framing, header byte, parity rule, CIPO 3-byte confirmation slot (4-state encoding, `0xFF` COMM_CHECK-fail sentinel) | **CIPO checksum: CRC-8/AUTOSAR (firmware update pending).** Other framing items: implemented, not yet stacked-panel bench-validated. |
 | `0x01` COMM_CHECK (byte-for-byte validation against canonical payload) | implemented |
 | `0x10` / `0x11` 2L Oneshot + Persistent, `0x30` / `0x31` 16L Oneshot + Persistent | implemented |
 | Duty cycle (BCM-via-PIO with fixed-period scan, default 1 kHz refresh) | implemented |

--- a/docs/development/g6_01-panel-protocol.md
+++ b/docs/development/g6_01-panel-protocol.md
@@ -101,7 +101,7 @@ The same procedure applies to the ISP extended-confirmation slot over its longer
 | Input bytes (hex) | Description | CRC |
 | :-- | :-- | :-- |
 | `01 10 00…00 00` (53 bytes: hdr + cmd + 50× zero pixels + duty=0) | 2L Oneshot all-zero | `0xC6` |
-| `81 30 00…00 00` (203 bytes: hdr+parity + cmd + 200× zero pixels + duty=0) | 16L Oneshot all-zero | `0x0C` |
+| `01 30 00…00 00` (203 bytes: hdr + cmd + 200× zero pixels + duty=0) | 16L Oneshot all-zero | `0x6D` |
 | `01 01 00 01 02 … C7` (202 bytes: COMM_CHECK canonical) | COMM_CHECK | `0x8B` |
 
 Implementers MUST verify their CRC implementation against both the universal `"123456789"` → `0xDF` check value and at least one protocol-specific vector before integration.

--- a/docs/development/g6_01-panel-protocol.md
+++ b/docs/development/g6_01-panel-protocol.md
@@ -1,30 +1,26 @@
 # G6 — Panel Protocol
 
-Source: G6 panels protocol v1 proposal ([Google Doc `17crYq4s...`](https://docs.google.com/document/d/17crYq4sdD1GhazOPS_Yi6UyGV6ugUy3WGnCWWw49r_0/edit#), tabs "Panel Version 1" → "Panel Version 4 and beyond" + "Panel Version Summary").
-Status: **§ v1 = Specified, partially implemented** (firmware: [`iorodeo/g6_firmware_devel`](https://github.com/iorodeo/g6_firmware_devel)) · **§ v2 = Teaser; opcodes declared in firmware but behavior not implemented** · **§ v3 = Teaser; Triggered + Gated modes prototyped in [`G6_Panels_Test_Firmware`](https://github.com/mbreiser/G6_Panels_Test_Firmware), Persistent reserved-but-deferred** · **§ v4 = ~30 % specified; zero firmware support; predefined-pattern flash mechanism is prerequisite to design** · **§ v5 = Sketch only**.
+SPI-level protocol between the controller and the panels — message framing, header byte, parity rule, command set, payload formats, panel confirmations, pixel data layout.
 
-This file holds the SPI-level protocol between the controller and the panels — message scaffolding, header byte, parity rule, the per-version command set, payload formats, panel confirmations, and pixel data layout. Versions are staged in chronological order (v1 first because it sets all the conventions and is the only version with deployable firmware in flight).
+The version byte (low 7 bits of byte 0) selects a **feature class**, not an implementation phase:
 
-## Live Divergences
+- **v1** (header `0x01`/`0x81`) — Live SPI display. Pattern arrives on each display command. All four display modes × 2L/16L grayscale, plus COMM_CHECK.
+- **v2** (header `0x02`/`0x82`) — PSRAM-backed display. Pattern lives in on-panel PSRAM; display commands reference it by index.
+- **v3** (header `0x03`/`0x83`) — Everything else: diagnostics, panel-flash predefined patterns, reserved range for future grayscale/color extensions.
+- **ISP** (uses v1 header with opcode block `0xE0`–`0xE4`) — In-system programming for panel firmware updates. Namespace-separated from display protocol.
 
-The v1 spec resolutions for the five spec ↔ firmware items (checksum scope, confirmation message, stretch behavior, COMM_CHECK visual response, LED-mapping layering) are reflected in the spec body below. **One latent firmware bug worth flagging for a fresh implementer:** `check_protocol()` in `iorodeo/g6_firmware_devel` (HEAD at last review, `@ 6944894`) compares the full header byte (including parity bit) against `CMD_PROTOCOL_V1 = 0x01` — it would reject a valid v1 message with parity = 1 (header `0x81`) if it were ever called by `Messenger::update()`. Currently dormant in v1 (not called from the message path); would surface at v2 unless fixed.
+Display commands across v1/v2/v3 share a **low-nibble-mode encoding**:
 
-**Two firmware tickets pending on the v1 side, beyond the bug above:**
+- High nibble = pattern type: `0x1x` = 2L Grayscale, `0x3x` = 16L Grayscale, `0x5x` = PSRAM-indexed (implicit `duty_cycle`), `0x6x` = PSRAM-indexed (explicit `duty_cycle` byte), `0x7x` = Predefined pattern.
+- Low nibble = mode: `0` = Oneshot, `1` = Persistent, `2` = Triggered, `3` = Gated.
 
-- `stretch` is parsed from the wire and stored on the `Pattern` object, but `Display::show()` does not yet scale BCM bit-plane ON-time durations by `stretch / 255` — see § Stretch Value below for the spec.
-- `Messenger::update()` does not yet write the panel-side confirmation message back on MISO during the next CS-active window — see § Confirmation message below for the spec.
+Display commands at the **`Fx` low nibble** are administrative (e.g., `0x3F` = PSRAM-write 16L). Reset commands (`0x0F`, `0x02`, `0x03`) do not follow the encoding.
 
-A V1 panel firmware implementer should treat fixing these three as the first concrete tasks before adding new features.
+Source: G6 panels protocol v1 proposal ([Google Doc `17crYq4s...`](https://docs.google.com/document/d/17crYq4sdD1GhazOPS_Yi6UyGV6ugUy3WGnCWWw49r_0/edit#)) and [`<will@iorodeo.com>`'s message format proposal](https://docs.google.com/document/d/1PTZqUxw04CUFtpy8vCtdnMF04zJVquuUo61HCXcoizs/edit). Implementation status of v1 firmware: see § [Implementation status](#implementation-status) at the end of this document.
 
 ---
 
 ## v1 — G6 Panel Protocol
-
-Based on `<will@iorodeo.com>`'s [G6 message format proposal](https://docs.google.com/document/d/1PTZqUxw04CUFtpy8vCtdnMF04zJVquuUo61HCXcoizs/edit), here is an updated request for comments for version 1 of the protocol between controller and panels.
-
-Thinking ahead, future versions could look similar to what is specified in [Version 2 (teaser)](#v2--g6-panel-protocol-v2-teaser), [Version 3 (teaser)](#v3--g6-panel-protocol-v3-teaser), or even [Version 4 and beyond](#v4--g6-panel-protocol-v4-teaser), but all of those developments will depend on the things we can learn from v1.
-
-Just to map out the space for commands, there is a preliminary list of commands in [Master command summary](#master-command-summary-v1v4), but all of this is subject to change.
 
 ### Message Format
 
@@ -58,20 +54,20 @@ The parity bit is set such that this count modulo 2 equals the parity bit value,
 
 **Parity Examples:**
 
-- 2-level oneshot (command `0x10`), all pixels=0, stretch=0 → header should be `0x01` (1 from version + 1 from command = 2 ones → parity 0)
-- 2-level oneshot (command `0x10`), all pixels=0, stretch=1 → header should be `0x81` (1 from version + 1 from command + 1 from stretch = 3 ones → parity 1)
-- 16-level oneshot (command `0x30`), all pixels=0, stretch=0 → header should be `0x81` (1 from version + 2 from command = 3 ones → parity 1)
+- 2-level oneshot (command `0x10`), all pixels=0, duty_cycle=0 → header should be `0x01` (1 from version + 1 from command = 2 ones → parity 0)
+- 2-level oneshot (command `0x10`), all pixels=0, duty_cycle=1 → header should be `0x81` (1 from version + 1 from command + 1 from duty_cycle = 3 ones → parity 1)
+- 16-level oneshot (command `0x30`), all pixels=0, duty_cycle=0 → header should be `0x81` (1 from version + 2 from command = 3 ones → parity 1)
 
-#### Stretch Value
+#### Duty Cycle Value
 
-The stretch value is a single byte (0–255) that scales the brightness of all pixels in a pattern by **modulating the BCM bit-plane ON-time durations** (not the pixel values themselves). Effective per-bit-plane ON time = `base_T × stretch / 255`, where `base_T` is the BCM base time (0.5 µs in the test rig). Stretch = 0 → all bit-planes have zero ON time → display off; stretch = 255 → unchanged from base BCM weights. This:
+The `duty_cycle` value is a single byte (0–255) that scales the brightness of all pixels in a pattern by **modulating the BCM bit-plane ON-time durations** (not the pixel values themselves). Effective per-bit-plane ON time = `base_T × duty_cycle / 255`, where `base_T` is the BCM base time (3.0 µs in v1 panel firmware). `duty_cycle = 0` → all bit-planes have zero ON time → display off. `duty_cycle = 255` → unchanged from base BCM weights.
 
-- Gives **per-frame uniform brightness control** without rewriting pixel values.
-- Enables **high dynamic range** via low-bit patterns + per-frame stretch (e.g., 4-level pattern at varying stretch yields finer effective brightness levels than 4-level alone).
-- Is **cheap on the panel** (one multiplier on the BCM weight array per frame; no per-pixel multiply).
-- Aligns with the test rig's **float-weight architecture** (`G6_Panels_Test_Firmware @ bb26a44` § BCMWEIGHTS), which already encodes per-bit-plane ON time as a float.
+**Brightness is linear in `duty_cycle` only when the scan period is fixed.** The panel firmware enforces a fixed scan period (1 kHz refresh by default), so the LED-off portion of the duty cycle scales correctly. Without this enforcement, low-duty-cycle scans run back-to-back and the perceived brightness ratio collapses. Achievable per-LED duty-cycle ratio between `duty_cycle=1` and `duty_cycle=255`: ~260× for Gray_2 patterns; ~1360× for Gray_16 patterns where intensity and duty cycle combine (theoretical max 15 × 255 = 3825× compressed by the PIO 5-cycle overhead floor at the lowest values).
 
-> **💡 Note — implementation status.** Stretch is parsed from the wire and stored on the `Pattern` object in `g6_firmware_devel @ 6944894`, but `Display::show()` does not yet apply it. Firmware ticket: scale BCM weights by `stretch/255` in the per-frame setup before bit-plane dispatch.
+Properties:
+- **Per-frame uniform brightness control** without rewriting pixel values.
+- **High dynamic range** via low-bit patterns + per-frame duty cycle (e.g., a 2-level pattern displayed across consecutive frames with stepped `duty_cycle` values yields a richer effective brightness range than the pattern's two intensity levels alone).
+- **Cheap on the panel** (one multiplier on the BCM weight array per frame; no per-pixel multiply).
 
 #### Endianness and Bit Packing
 
@@ -81,7 +77,7 @@ little-endian for all multi-byte integers. Pack pixels MSB-first within each byt
 
 Each message SHALL be transmitted as exactly one SPI transaction, bounded by chip-select (CS). The message begins on CS falling edge and ends on CS rising edge. The controller and panel SHALL reset their message parsers on CS rising edge.
 
-**SPI mode**: CPOL=1, CPHA=1 (SPI Mode 3), MSB-first. **Clock**: panels accept up to 30 MHz (firmware default in `g6_firmware_devel/panel/src/constants.cpp`). Cross-platform implementations SHOULD configure the same.
+**SPI mode**: CPOL=1, CPHA=1 (SPI Mode 3), MSB-first. **Clock**: panels accept up to 30 MHz (firmware default in [`reiserlab/LED-Display_G6_Firmware_Panel/panel/src/constants.cpp`](https://github.com/reiserlab/LED-Display_G6_Firmware_Panel/blob/feat/v1-stage1-protocol/panel/src/constants.cpp)). Cross-platform implementations SHOULD configure the same.
 
 A message from the controller to the panel is defined by the "protocol commands". The panels return the header and command from the previously received message followed by an 8-bit checksum.
 
@@ -91,19 +87,29 @@ The controller SHALL clock exactly the number of bytes required by the command f
 
 If any validation fails (unsupported protocol version, unsupported command, incorrect message length, parity failure), the panel SHALL discard the message.
 
-### Implemented Commands
+### Commands
 
-Version 1 of the protocol supports only three commands (controller → panel):
-
-- `0x01` — Communication check
-- `0x10` — Display 2-Level Grayscale (Oneshot)
-- `0x30` — Display 16-Level Grayscale (Oneshot)
+v1 covers nine display commands (four modes × two grayscale resolutions, plus COMM_CHECK). All carry the pattern data on-the-wire — the panel does not need to retain anything between display calls.
 
 | Header (parity) | Header (version) | Cmd | Payload bytes | Total bytes | Name |
 | :-: | :-: | :-: | :-: | :-: | :-- |
 | 0\|1 | 1 | `0x01` | 200 | 202 | `COMM_CHECK` |
-| 0\|1 | 1 | `0x10` | 51 (50 + stretch) | 53 | `DISP_2LVL_ONESHOT` |
-| 0\|1 | 1 | `0x30` | 201 (200 + stretch) | 203 | `DISP_16LVL_ONESHOT` |
+| 0\|1 | 1 | `0x10` | 51 (50 + duty_cycle) | 53 | `DISP_2LVL_ONESHOT` |
+| 0\|1 | 1 | `0x11` | 51 (50 + duty_cycle) | 53 | `DISP_2LVL_PERSIST` |
+| 0\|1 | 1 | `0x12` | 51 (50 + duty_cycle) | 53 | `DISP_2LVL_TRIGGERED` |
+| 0\|1 | 1 | `0x13` | 51 (50 + duty_cycle) | 53 | `DISP_2LVL_GATED` |
+| 0\|1 | 1 | `0x30` | 201 (200 + duty_cycle) | 203 | `DISP_16LVL_ONESHOT` |
+| 0\|1 | 1 | `0x31` | 201 (200 + duty_cycle) | 203 | `DISP_16LVL_PERSIST` |
+| 0\|1 | 1 | `0x32` | 201 (200 + duty_cycle) | 203 | `DISP_16LVL_TRIGGERED` |
+| 0\|1 | 1 | `0x33` | 201 (200 + duty_cycle) | 203 | `DISP_16LVL_GATED` |
+
+All four modes share the same payload shape per pattern type — only the mode (low nibble of cmd byte) differs.
+
+**Default operating model: controller-driven, one-shot per command.** The expected production model is that the controller continuously streams commands to the panel — one command per intended stimulus event. Under this model, **Oneshot (`0x?0`), Triggered (`0x?2`), and Gated (`0x?3`) are all one-shot semantically**: a command arms the panel for one display unit (one scan / one trigger consumption / one gate cycle — see per-mode descriptions for precise definitions), after which the panel goes dark/idle until a new command arrives.
+
+**Persistent (`0x?1`) is the special-case exception** — the panel keeps refreshing the loaded pattern indefinitely without further commands. Useful for static backgrounds, single-panel bench tests, and low-SPI-bandwidth scenarios, but not the canonical production case.
+
+The Triggered and Gated commands require the EINT trigger line; without an active EINT source they're functionally equivalent to a no-op load (pattern accepted, no display until EINT activity).
 
 #### `0x01` — Communication check
 
@@ -119,9 +125,9 @@ Send a known message; the panel silently validates it (byte-for-byte against the
 
 #### `0x10` — Display 2-Level Grayscale (Oneshot)
 
-Displays a 2-level (1-bit per pixel) pattern once.
+Displays a 2-level (1-bit per pixel) pattern **once** — a single BCM scan, then the panel idles dark until the next display command.
 
-**Payload**: 50 bytes of pattern data & 1 byte stretch value
+**Payload**: 50 bytes of pattern data & 1 byte duty_cycle value
 
 - 20×20 pixels in row-major order
 - 1 bit per pixel (0=off, 1=on)
@@ -129,13 +135,54 @@ Displays a 2-level (1-bit per pixel) pattern once.
 
 **Example**:
 
-`[0x01] [0x10] [pixel data: 50 bytes] [stretch]`
+`[0x01] [0x10] [pixel data: 50 bytes] [duty_cycle]`
+
+#### `0x11` — Display 2-Level Grayscale (Persistent)
+
+Same payload shape as `0x10`; mode differs. Pattern is loaded into the display engine and **scanned continuously** until a new display command replaces it. Use for static backgrounds, single-panel bench tests, and low-SPI-bandwidth scenarios. For frame-by-frame deterministic stimulus delivery, prefer `0x10` Oneshot streamed by the controller.
+
+**Example**:
+
+`[0x01] [0x11] [pixel data: 50 bytes] [duty_cycle]`
+
+#### `0x12` — Display 2-Level Grayscale (Triggered)
+
+Same payload shape as `0x10`. **One-shot Triggered semantics**: pattern is loaded by this command, then fired by EINT rising edges. Each rising edge fires **one row × all 4 BCM bit-planes for that row** (the panel scans row-by-row; 20 row drivers, 20 column drivers — see [`g6_02-led-mapping.md`](g6_02-led-mapping.md) § Hardware Reference).
+
+**Consumption rule**: 20 EINT rising edges complete one full frame, after which the panel returns to dark/idle. The controller re-arms with a new `0x12` command for each subsequent stimulus burst.
+
+**Overwrite-on-new-pattern**: if a new display command arrives before the 20 EINT edges complete, the new pattern overwrites the current one and the internal row counter resets to 0. Intermediate patterns are silently discarded. If the controller pushes Triggered patterns faster than 20 edges arrive between commands, the older pattern's rows never fire — this is a controller-side monitoring responsibility (no panel-side warning today).
+
+**Between-edge state**: the panel is naturally dark between EINT rising edges. Each edge fires one row × all 4 bit-planes briefly, then the row goes inactive. If EINT stops mid-burst (e.g., the scanner halts before delivering all 20 edges), the panel is dark from that point until either more edges arrive or a new pattern arms a fresh row-0 fire. No stuck-pixel state — no timeout fallback is required.
+
+**Example**: `[0x01] [0x12] [pixel data: 50 bytes] [duty_cycle]`
+
+Use case: sub-frame synchronization with external scanning systems (two-photon microscope resonant scanners, etc.). Trigger-to-LED latency measured at 865 ± 17 ns at 8 kHz on prototype hardware; will be remeasured on production arena hardware.
+
+#### `0x13` — Display 2-Level Grayscale (Gated)
+
+Same payload shape as `0x10`. **One-shot Gated semantics**: pattern processing follows the normal Oneshot model (one scan per command, queue drain-to-latest as in `0x10`). The EINT signal acts as a **global output-enable gate**, operating independently of the command/pattern stream:
+
+- **EINT HIGH** → LED output enabled: the panel displays the most recent queued pattern at the standard BCM scan rate (continuous refresh while HIGH, since the controller is still streaming Oneshot commands to keep new frames coming in).
+- **EINT LOW** → LED output disabled: panel goes dark. The pattern queue keeps building as new `0x13` (or `0x10`/`0x11`/etc.) commands arrive; they're processed but not visibly displayed.
+
+The controller is expected to stream patterns at its normal cadence regardless of gate state — the gate is a downstream output mask, not a flow-control signal. When the gate transitions LOW→HIGH → the latest pattern that's been queued during the LOW interval becomes visible; when the gate transitions HIGH→LOW → output is masked off immediately.
+
+**Gate timing details:**
+
+- **Mid-scan HIGH→LOW transition**: the gate is taken strictly. The panel stops scanning and stops displaying at the moment of the transition (LEDs go dark within one bit-plane interval). Partially-scanned rows are abandoned; the next LOW→HIGH transition starts fresh with whatever pattern is then queue-latest.
+- **Initial state**: if EINT is HIGH when the first `0x13` command arrives but no prior pattern has been processed, the panel displays nothing until the first pattern is processed. The gate cannot reveal a pattern that doesn't exist yet.
+- **Stale queue on LOW→HIGH transition**: the queue drains to the latest pattern at the moment of the transition. Older patterns that were enqueued during the LOW window are discarded (with `frames_skipped_` incremented). This matches the existing drain-to-latest semantics in v1's Oneshot path.
+
+**Example**: `[0x01] [0x13] [pixel data: 50 bytes] [duty_cycle]`
+
+Use case: window-gated display for behavior-rig event windows. The rig's event-window controller drives EINT; the panel controller streams patterns at its own cadence; the animal sees patterns only during event windows. The two control streams are decoupled, which simplifies the controller-side software and makes the event-window timing precise (driven by the rig clock, not the SPI clock).
 
 #### `0x30` — Display 16-Level Grayscale (Oneshot)
 
-Displays a 16-level (4-bit per pixel) pattern once.
+Displays a 16-level (4-bit per pixel) pattern **once** — single BCM scan, then idle.
 
-**Payload**: 200 bytes of pattern data & 1 byte stretch value
+**Payload**: 200 bytes of pattern data & 1 byte duty_cycle value
 
 - 20×20 pixels in row-major order
 - 4 bits per pixel (0–15 intensity levels)
@@ -143,36 +190,75 @@ Displays a 16-level (4-bit per pixel) pattern once.
 
 **Example**:
 
-`[0x01] [0x30] [pixel data: 200 bytes] [stretch]`
+`[0x01] [0x30] [pixel data: 200 bytes] [duty_cycle]`
+
+#### `0x31` — Display 16-Level Grayscale (Persistent)
+
+Same payload shape as `0x30`; pattern scanned continuously until next command. Same trade-off vs. Oneshot as `0x11` vs `0x10`.
+
+**Example**:
+
+`[0x01] [0x31] [pixel data: 200 bytes] [duty_cycle]`
+
+#### `0x32` — Display 16-Level Grayscale (Triggered)
+
+Same payload shape as `0x30`. **Semantics per `0x12`**: one row × all 4 BCM bit-planes per EINT rising edge; 20 edges = one frame consumed → panel returns to dark; new pattern mid-consumption overwrites.
+
+**Example**: `[0x01] [0x32] [pixel data: 200 bytes] [duty_cycle]`
+
+#### `0x33` — Display 16-Level Grayscale (Gated)
+
+Same payload shape as `0x30`. **Semantics per `0x13`**: pattern processing follows normal Oneshot; EINT is a global output-enable mask. Gate HIGH → LEDs visible; Gate LOW → panel dark (queue still building); mid-scan transition stops scanning immediately.
+
+**Example**: `[0x01] [0x33] [pixel data: 200 bytes] [duty_cycle]`
 
 ### Confirmation message
 
-> **💡 Note** — confirmation message is specified normatively below; firmware impl pending in `g6_firmware_devel` (panel-side MISO write logic not yet wired).
-
-On CS falling edge, a panel returns the version, command, and a checksum from the previously received command.
-
-When the panel receives a command, it stores the header, version, and calculates an 8-bit checksum **over the whole message** (header byte + command byte + payload bytes, sum mod 256). For invalid commands no information is stored, since they are ignored. This happens, for example, when the parity bit does not match the content, or when the message length does not match the command definition.
-
-The next time CS is active for **at least 3 bytes** (`≥3`), the panel sends this confirmation message (recalculating the parity bit). After sending it successfully, the temporary buffer is deleted: each confirmation message is sent only once. Since every valid v1 message is at least 3 bytes (header + cmd + ≥1 payload byte), every valid incoming message triggers the previous message's confirmation.
-
-If the panel buffer is empty, it returns header `0x81` followed by command `0x00` (i.e., on-wire bytes `[0x81] [0x00]`, signaling "empty command 0").
-
-We use an 8-bit (simple additive) checksum over the whole message since this is faster to calculate than CRC, SHA, or other error-detecting algorithms (one loop over the receive buffer). Matches `Message::calculate_8bit_checksum()` in `g6_firmware_devel @ 6944894` ([message.cpp:171–177](../../../g6_firmware_devel/panel/src/message.cpp)). (Note: the panel-confirmation checksum here is **additive** (sum mod 256); the [pattern-file checksum in `g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md) is **XOR**. Both are confirmed against firmware; the two algorithms intentionally differ.)
-
-**Example:**
+On CS falling edge, a panel returns a **3-byte confirmation slot** describing the previously received command:
 
 ```
-COPI: [0x01] [0x10] [pixel data 1: 50 bytes]  [stretch 1]
-CIPO: [0x81] [0x00]
-…
-COPI: [0x01] [0x30] [pixel data 2: 200 bytes] [stretch 2]
-CIPO: [0x_1] [0x10] [checksum pixel data 1 + stretch]
-…
-COPI: [0x01] [0x30] [pixel data 3: 200 bytes] [stretch 3]
-CIPO: [0x_1] [0x30] [checksum pixel data 2 + stretch]
+[byte 0: header_with_parity]  [byte 1: cmd_or_sentinel]  [byte 2: checksum]
 ```
 
-`[0x_1]` is shorthand for "either `0x01` or `0x81`" depending on the parity bit recomputed for the confirmation message.
+When the panel receives a valid command, it stores the version (from the incoming header), the command byte, and an 8-bit checksum **over the whole incoming message** (header byte + command byte + payload bytes, sum mod 256). The header byte in the confirmation slot echoes the **incoming protocol version** (`0x01` for V1; in future, `0x02` for V2) with the parity bit **recomputed** over the 3-byte confirmation message.
+
+For invalid commands (parity failure, length mismatch, unsupported protocol version, unknown command, etc.) the buffer is **not updated** — the panel continues to return whatever was in the slot before. This preserves the spec invariant "for invalid commands no information is stored."
+
+The 3-byte slot is **cleared** by the panel only after at least 3 bytes have been clocked out on CIPO. If the controller asserts CS for fewer than 3 byte windows, the slot stays armed for the next CS-active window. (Every valid panel-protocol message is ≥ 3 bytes — header + cmd + ≥ 1 payload byte — so any normal traffic cycle clears the previous confirmation.)
+
+**4-state encoding** (normative; matches firmware behavior):
+
+| Slave state | Bytes returned on next CIPO |
+| :-- | :-- |
+| No prior message (boot, or last confirmation already drained) | `{0x81, 0x00, 0x00}` — parity-correct empty-buffer sentinel (header parity = 1 ⊕ cmd=0 ⊕ checksum=0 ⇒ header byte `0x81`) |
+| Last message valid + COMM_CHECK passed | `{header_with_parity, cmd, checksum}` |
+| Last message was COMM_CHECK and byte-mismatched | `{header_with_parity, 0xFF, 0x00}` — `0xFF` is the **reserved COMM_CHECK-fail sentinel** (see Master command summary); checksum is `0x00` because the slot has no real payload to checksum (the message was rejected). Header parity recomputed against `{version, 0xFF, 0x00}`. |
+| Last message invalid for any other reason (parity, length, unsupported, unknown cmd) | Slot unchanged — controller observes the previous confirmation. |
+
+**`cmd = 0xFF` is reserved panel-side** for the COMM_CHECK-fail sentinel and MUST NOT be issued by a controller. See Master command summary § Reserved confirmation values.
+
+The 8-bit additive checksum (sum mod 256) is faster to compute than CRC/SHA — a single loop over the receive buffer. Matches `Message::calculate_8bit_checksum()` in `reiserlab/LED-Display_G6_Firmware_Panel @ feat/v1-stage1-protocol` ([message.cpp:171–177](https://github.com/reiserlab/LED-Display_G6_Firmware_Panel/blob/feat/v1-stage1-protocol/panel/src/message.cpp#L171-L177)). (Note: the panel-confirmation checksum here is **additive** (sum mod 256); the [pattern-file checksum in `g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md) is **XOR**. Both are confirmed against firmware; the two algorithms intentionally differ.)
+
+**Examples:**
+
+```
+COPI: [0x01] [0x10] [pixel data 1: 50 bytes]  [duty_cycle 1]      // first valid message ever (2L Oneshot)
+CIPO: [0x81] [0x00] [0x00]                                      // boot empty-buffer sentinel
+…
+COPI: [0x01] [0x30] [pixel data 2: 200 bytes] [duty_cycle 2]      // valid 16L Oneshot
+CIPO: [0x_1] [0x10] [checksum-of-message-1]                     // echo of message 1
+…
+COPI: [0x01] [0x31] [pixel data 3: 200 bytes] [duty_cycle 3]      // valid 16L Persistent
+CIPO: [0x_1] [0x30] [checksum-of-message-2]                     // echo of message 2
+…
+COPI: [0x01] [0x01] [byte-corrupted COMM_CHECK payload]        // COMM_CHECK with one byte flipped
+CIPO: [0x_1] [0x31] [checksum-of-message-3]                     // echo of message 3
+…
+COPI: [0x01] [0x11] [pixel data 4: 50 bytes] [duty_cycle 4]       // valid 2L Persistent
+CIPO: [0x_1] [0xFF] [0x00]                                      // COMM_CHECK FAIL sentinel from prior frame
+```
+
+`[0x_1]` is shorthand for "either `0x01` or `0x81`" — the actual parity bit is recomputed for each 3-byte confirmation message.
 
 ### Pixel Data Format
 
@@ -255,199 +341,179 @@ Suggested errors to surface: unknown/uninterpretable command, payload-length mis
 
 ---
 
-## v2 — G6 Panel Protocol v2 (teaser)
+## v2 — G6 Panel Protocol v2 — PSRAM-backed display
 
-Version 2 of the protocol extends v1 by adding PSRAM (Pseudo-Static RAM) support, enabling panels to store multiple patterns in memory and display them on demand. While protocol version 1 is already able to emulate all the commands G4 can support, protocol version 2 should be capable of handling higher framerates and might be a first useful version to release to the community.
+Version 2 adds **PSRAM** (Pseudo-Static RAM) for on-panel pattern storage. The controller pre-uploads patterns to indexed slots, then displays them via short index-only commands. This trades upload cycles for runtime SPI bandwidth — useful for closed-loop stimulus libraries with hundreds of pre-computed frames where the on-the-wire cost of `0x30`/`0x31` 16-Level commands (203 bytes each) becomes prohibitive at high frame rates.
 
 For Protocol v2, the version bits are `0b0000010`, giving possible header values `0x02` (parity 0) / `0x82` (parity 1).
 
-**Compatibility:** Panels implementing protocol version N MUST accept all commands from versions 1 through N. The version-bits in the header byte select which command set is dispatched, but a v2 panel receiving a header `[0x01]` with a v1 command MUST handle it as a valid v1 command. This rule is what lets v3 workflow examples mix v2 commands (e.g., `0x1F` Write 2-Level to PSRAM) into v3 sequences without conflict. (Scope of which commands carry over per version may be narrowed during implementation review — TBD.)
+**Compatibility:** A v2 panel MUST accept all v1 commands (header `0x01`/`0x81`). A v1 panel MAY reject v2 commands; the controller is expected to query panel capabilities (mechanism TBD with v2 design) before issuing them.
 
-### Additional Commands (v2)
+> **⚠ Status.** v2 PSRAM ops have open semantic questions (PSRAM addressing model, behavior on out-of-range index, power-loss-mid-write, slot collision with v3 predefined patterns) that must be resolved before firmware implementation begins. The opcode table is a working baseline.
 
-- `0x02` — Query diagnostics
-- `0x03` — Reset diagnostic stats
-- `0x0F` — Reset PSRAM
-- `0x1F` — Write 2-Level Grayscale to PSRAM
-- `0x3F` — Write 16-Level Grayscale to PSRAM
-- `0x50` — Display PSRAM Index (Oneshot)
+### v2 Commands
 
-#### `0x02` — Query diagnostics
+Opcode encoding follows the low-nibble-mode rule (`0`=Oneshot, `1`=Persistent, `2`=Triggered, `3`=Gated). PSRAM-display opcodes come in two flavors: `0x5x` uses the duty_cycle value stored at PSRAM-write time (implicit), and `0x6x` carries an explicit per-display duty_cycle byte (lets the controller display the same stored pattern at multiple brightness levels without re-uploading).
 
-Get the diagnostics from the panel. We should circle back to this once v1 is implemented; current ideas from `<will@iorodeo.com>` include counting the number of bad bytes, short messages, or other error rates. Statistics could either be collected from `0x01` messages or from all messages sent since the last reset.
+- `0x0F` — Reset PSRAM (clear user-stored patterns)
+- `0x3F` — Write 16-Level Grayscale pattern to PSRAM
+- `0x50` / `0x51` / `0x52` / `0x53` — Display PSRAM Index in Oneshot / Persistent / Triggered / Gated (duty_cycle implicit, from PSRAM-write time)
+- `0x60` / `0x61` / `0x62` / `0x63` — Display PSRAM Index with explicit duty_cycle in Oneshot / Persistent / Triggered / Gated
 
-**Payload**: None (0 bytes)
-
-**Example**:
-
-`[0x02] [0x02]`
-
-> **⚠ Flag — diagnostic data shape unspecified.** Spec the diagnostic record format (counters, error codes, response carrier slot) before this command becomes implementable.
-
-#### `0x03` — Reset diagnostic stats
-
-Reset the diagnostic counter.
-
-**Payload**: None (0 bytes)
-
-**Example**:
-
-`[0x82] [0x03]`
+**Removed from earlier drafts:** 2-Level PSRAM write (`0x1F`). v2 supports PSRAM storage for 16-Level only. 2-Level live patterns are 53 bytes each over SPI — bandwidth-efficient enough that PSRAM storage isn't worth the design complexity.
 
 #### `0x0F` — Reset PSRAM
 
-Clears all user-stored patterns from PSRAM, keeping only factory predefined patterns.
+Clears all user-stored patterns from PSRAM (preserves predefined patterns under v3 `0x70`–`0x73`, if those use a separate flash region — see v3).
 
 **Payload**: None (0 bytes)
 
-**Example**:
-
-`[0x82] [0x0F]`
-
-**Purpose**: Reset the panel's PSRAM to a clean state, removing all patterns stored via commands `0x1F` and `0x3F`.
-
-- Starting a new experimental session with fresh memory
-- Ensuring a known initial state before loading new patterns
-
-#### `0x1F` — Write 2-Level Grayscale to PSRAM
-
-Writes a 2-level (1-bit per pixel) pattern to PSRAM for later retrieval.
-
-**Payload**: 54 bytes (3 idx + 50 pattern + 1 stretch)
-
-- **Bytes 2–4**: PSRAM index/location (3 bytes, 24-bit integer)
-- **Bytes 5–54**: Pattern data (50 bytes)
-  - 20×20 pixels in row-major order
-  - 1 bit per pixel (0=off, 1=on)
-  - Total: 400 pixels / 8 = 50 bytes
-- **Byte 55**: stretch value
-
-**Example**:
-
-`[0x02] [0x1F] [index: 3 bytes] [pixel data: 50 bytes] [stretch]`
-
-**Purpose**: Store patterns in the panel's PSRAM instead of transmitting them every time. This reduces transmission overhead during high-speed pattern sequences and enables efficient pattern libraries. (Multi-byte index follows the file-wide little-endian convention from [`g6_00-architecture.md`](g6_00-architecture.md); same applies to `0x3F` and `0x50`.)
+**Example**: `[0x82] [0x0F]`
 
 #### `0x3F` — Write 16-Level Grayscale to PSRAM
 
-Writes a 16-level (4-bit per pixel) pattern to PSRAM for later retrieval.
+Writes a 16-level (4-bit per pixel) pattern to PSRAM for later retrieval by `0x5x` (implicit duty_cycle) or `0x6x` (explicit duty_cycle) Display PSRAM Index commands.
 
-**Payload**: 204 bytes (3 idx + 200 pattern + 1 stretch)
+**Payload**: 204 bytes (3 idx + 200 pattern + 1 duty_cycle)
 
-- **Bytes 2–4**: PSRAM index/location (3 bytes, 24-bit integer)
-- **Bytes 5–204**: Pattern data (200 bytes)
-  - 20×20 pixels in row-major order
-  - 4 bits per pixel (0–15 intensity levels)
-  - Total: 400 pixels × 4 bits / 8 = 200 bytes
-- **Byte 205**: stretch value
+- **Bytes 2–4**: PSRAM index/location (3 bytes, 24-bit little-endian integer)
+- **Bytes 5–204**: Pattern data (200 bytes, 20×20 × 4bpp row-major MSB-first)
+- **Byte 205**: duty_cycle value (stored alongside the pattern; used by `0x5x` display commands; ignored by `0x6x` since those carry their own duty_cycle byte)
 
 **Example**:
 
-`[0x02] [0x3F] [index: 3 bytes] [pixel data: 200 bytes] [stretch]`
+`[0x02] [0x3F] [index: 3 bytes] [pixel data: 200 bytes] [duty_cycle]`
 
-**Purpose**: Same as `0x1F` but for higher grayscale resolution patterns. Allows storage of more complex visual stimuli with 16 distinct brightness levels.
+> **⚠ Open question — PSRAM addressing semantics.** Is the 24-bit index a byte address, a fixed-size slot index, a record handle, or a typed reference? What's the maximum allowed index? What happens on out-of-range, on collision with predefined-pattern slots (v3 `0x70`–`0x73` live in a separate flash region, but the addressing convention should be aligned across both), on power-loss mid-write? These need a half-page subsection before v2 firmware.
 
-#### `0x50` — Display PSRAM Index (Oneshot)
+#### `0x50` / `0x51` / `0x52` / `0x53` — Display PSRAM Index (implicit duty_cycle)
 
-Displays a pattern that was previously stored in PSRAM using command `0x1F` or `0x3F`.
+Display a previously-stored PSRAM pattern by index, in one of the four display modes. The `duty_cycle` value used is **the one stored alongside the pattern** via `0x3F`. Mode semantics follow the v1 default (Oneshot / Triggered / Gated all one-shot, Persistent the special case) — see v1 § Display Mode Summary and the open questions under v1 `0x12` / `0x13`.
 
-**Payload**: 3 bytes
+| Cmd | Mode | Notes |
+|:-:|:--|:--|
+| `0x50` | Oneshot                | one scan, then dark |
+| `0x51` | Persistent             | continuous refresh until next command (special-case exception) |
+| `0x52` | Triggered (one-shot)   | per-edge firing per v1 `0x12`: 20 EINT edges = one frame, then dark; new pattern overwrites mid-consumption |
+| `0x53` | Gated (one-shot)       | output-enable model per v1 `0x13`: HIGH = LEDs visible, LOW = dark; queue keeps building during LOW |
 
-- **Bytes 2–4**: PSRAM index/location (3 bytes, 24-bit integer)
+**Payload**: 3 bytes — PSRAM index (24-bit little-endian).
 
 **Example**:
 
-`[0x02] [0x50] [index: 3 bytes]`
+```
+[0x02] [0x50] [0x00 0x00 0x00]      // display PSRAM index 0 once at stored duty_cycle
+[0x02] [0x51] [0x01 0x00 0x00]      // display PSRAM index 1 persistently at stored duty_cycle
+```
 
-**Purpose**: Display a pre-stored pattern immediately (oneshot = display once). This provides:
+#### `0x60` / `0x61` / `0x62` / `0x63` — Display PSRAM Index with explicit duty_cycle
 
-- **Fast pattern switching**: Only 5 bytes total (header + command + 3-byte index) need to be transmitted instead of 52–202 bytes
-- **Efficient memory usage**: Store patterns once, reference them by index
-- **Reduced bandwidth**: Critical for high-frequency pattern sequences
+Display a previously-stored PSRAM pattern by index, in one of the four display modes, **using a per-display duty_cycle byte** (overriding the stored duty_cycle). Lets the controller show the same stored pattern at multiple brightness levels without re-uploading.
+
+| Cmd | Mode | Notes |
+|:-:|:--|:--|
+| `0x60` | Oneshot                | one scan, then dark |
+| `0x61` | Persistent             | continuous refresh until next command (special case) |
+| `0x62` | Triggered (one-shot)   | semantics per v1 `0x12`: 20 EINT edges = one frame, then dark |
+| `0x63` | Gated (one-shot)       | semantics per v1 `0x13`: output-enable gate, queue keeps building during LOW |
+
+**Payload**: 4 bytes — PSRAM index (3 bytes, 24-bit little-endian) + duty_cycle (1 byte).
+
+**Example**:
+
+```
+[0x02] [0x60] [0x00 0x00 0x00] [0x40]    // display PSRAM index 0 once at duty_cycle=64
+[0x02] [0x60] [0x00 0x00 0x00] [0xFF]    // same pattern again at full brightness
+```
 
 ### Typical v2 Workflow
 
-1. **Pre-load patterns into PSRAM**:
+1. **Pre-load patterns into PSRAM** (16-Level only):
 
    ```
-   [0x02] [0x1F] [0x00 0x00 0x00] [pattern 0 data…] [0xC0]   // stretch 192, index 0
-   [0x02] [0x1F] [0x01 0x00 0x00] [pattern 1 data…] [0x05]   // stretch 5, index 1 (little-endian)
-   [0x02] [0x3F] [0x02 0x00 0x00] [pattern 2 data…] [0x20]   // stretch 32, index 2 (little-endian)
+   [0x02] [0x3F] [0x00 0x00 0x00] [pattern 0 data: 200 bytes] [0xC0]   // index 0, duty_cycle 192
+   [0x02] [0x3F] [0x01 0x00 0x00] [pattern 1 data: 200 bytes] [0x05]   // index 1, duty_cycle 5
+   [0x02] [0x3F] [0x02 0x00 0x00] [pattern 2 data: 200 bytes] [0x20]   // index 2, duty_cycle 32
    ```
 
-2. **Display patterns by index during experiment**:
+2. **Display patterns by index in any mode (implicit duty_cycle)**:
 
    ```
-   [0x02] [0x50] [0x00 0x00 0x00]                              // index 0
-   [0x02] [0x50] [0x01 0x00 0x00]                              // index 1 (little-endian)
-   [0x02] [0x50] [0x02 0x00 0x00]                              // index 2 (little-endian)
+   [0x02] [0x50] [0x00 0x00 0x00]    // index 0, Oneshot, duty_cycle from PSRAM (192)
+   [0x02] [0x51] [0x01 0x00 0x00]    // index 1, Persistent, duty_cycle from PSRAM (5)
+   [0x02] [0x53] [0x02 0x00 0x00]    // index 2, Gated (refresh while EINT HIGH), duty_cycle from PSRAM (32)
+   ```
+
+3. **Or display with explicit duty_cycle override**:
+
+   ```
+   [0x02] [0x60] [0x00 0x00 0x00] [0x40]   // index 0, Oneshot at duty_cycle=64 (overrides stored 192)
+   [0x02] [0x61] [0x00 0x00 0x00] [0xFF]   // same index 0, now Persistent at full duty_cycle
    ```
 
 (Example headers use `[0x02]` throughout; the actual parity bit depends on the elided pattern payloads — recompute when concrete patterns are chosen for a worked example.)
 
-## v3 — G6 Panel Protocol v3 (teaser)
+## v3 — G6 Panel Protocol v3 — Diagnostics, predefined patterns, future feature classes
 
-Version 3 adds high-performance modes to the existing protocol. This takes advantage of the PSRAM and the additional trigger line, allowing synchronized displays with imaging setups. This release will enable a whole new set of experiments, precisely controlling the timing of visual stimuli to the rest of the experimental rigs.
+Version 3 covers everything that isn't live-SPI display (v1) or PSRAM-backed display (v2): **diagnostics**, **predefined patterns** stored in panel flash, and a placeholder for future feature classes (additional grayscale levels, color support).
 
 For Protocol v3, the version bits are `0b0000011`, giving possible header values `0x03` (parity 0) / `0x83` (parity 1).
 
-### Display Modes
+**Compatibility:** A v3 panel MUST accept all v1 + v2 commands.
 
-Protocol v3 introduces three new display modes alongside v1's Oneshot:
+> **⚠ Status.** v3 feature classes are pre-design: diagnostics needs a data-shape spec (counters, error codes, response carrier); predefined patterns needs a flash-region design (slot count, factory vs. user-installable, programming mechanism — likely reuses ISP primitives over a different region).
 
-- **Oneshot** (v1 default): Display the pattern once immediately. Controller drives every frame. Most deterministic; canonical for G6.
-- **Triggered**: Each rising edge on the EINT trigger line fires **one row of the loaded pattern, displayed across all 4 BCM bit-planes for that row** (the panel scans row-by-row; 20 row drivers, 20 column drivers — see [`g6_02-led-mapping.md`](g6_02-led-mapping.md) § Hardware Reference). Pattern stays loaded; subsequent rising edges advance through the remaining rows of the frame, then wrap. Validated in `G6_Panels_Test_Firmware @ bb26a44` with 865 ± 17 ns trigger-to-LED latency at 8 kHz. Use case: sub-frame sync with external scanning systems (two-photon microscope resonant scanners, etc.).
-- **Gated**: While EINT HIGH, the panel internally refreshes the loaded frame; while LOW, display off. Pattern remains loaded across HIGH↔LOW transitions until a new command. Use case: window-gated display for behavior-rig event windows.
-- **Persistent** *(proposed; not implemented in initial v3)*: Display continuously until next command. Reserved opcodes (`0x13`/`0x33`/`0x53`) — controller-per-frame Oneshot is the canonical deterministic approach today.
+### v3 Commands
 
-### v3 commands
+- `0x02` — Query diagnostics (data shape TBD)
+- `0x03` — Reset diagnostic stats
+- `0x70` / `0x71` / `0x72` / `0x73` — Display Predefined Pattern in Oneshot / Persistent / Triggered / Gated
 
-Nine display opcodes covering 3 modes × 3 pattern types:
+(Future feature classes — additional grayscale levels via `0x20`/`0x40`/`0x80` pattern-type nibbles, color support — are out-of-scope for this revision of the spec; see § Open Questions / TBDs.)
 
-| Opcode | Pattern type | Mode | Payload | Status |
-|:-:|:--|:--|:--|:--|
-| `0x12` | 2-Level (50 B + stretch = 51 B) | Triggered | `[0x03] [0x12] [50 B pixels] [stretch]` | active |
-| `0x13` | 2-Level | Persistent | same shape as `0x12` | reserved (proposed, not implemented) |
-| `0x14` | 2-Level | Gated | same shape as `0x12` | active |
-| `0x32` | 16-Level (200 B + stretch = 201 B) | Triggered | `[0x03] [0x32] [200 B pixels] [stretch]` | active |
-| `0x33` | 16-Level | Persistent | same shape as `0x32` | reserved (proposed, not implemented) |
-| `0x34` | 16-Level | Gated | same shape as `0x32` | active |
-| `0x52` | PSRAM Index (3 B) | Triggered | `[0x03] [0x52] [3 B index]` | active |
-| `0x53` | PSRAM Index | Persistent | same shape as `0x52` | reserved (proposed, not implemented) |
-| `0x54` | PSRAM Index | Gated | same shape as `0x52` | active |
+#### `0x02` — Query diagnostics
 
-Pattern-type encoding details inherit from v1 (2-Level / 16-Level) and v2 (PSRAM Index, 24-bit address). Stretch (where present) is BCM duty-cycle multiplier per v1 § Stretch Value.
+Get diagnostics from the panel. Current candidates from `<will@iorodeo.com>`: counts of bad bytes, short messages, parity failures, queue drops, or other error rates. Statistics could be collected from `0x01` COMM_CHECK responses or from all messages since the last reset.
 
-### Typical v3 Workflows
+**Payload**: None (0 bytes)
 
-**Two-photon microscopy with triggered display** (per-trigger-edge firing):
+**Example**: `[0x03] [0x02]`
+
+> **⚠ Flag — diagnostic data shape unspecified.** Spec the diagnostic record format (counters, error codes, response carrier slot) before this command becomes implementable. The CIPO confirmation slot is 3 bytes — diagnostic data exceeds that, so a separate response mechanism is needed (extended slot? streamed over CIPO with explicit length? mailbox via PSRAM?).
+
+#### `0x03` — Reset diagnostic stats
+
+Reset the diagnostic counter(s).
+
+**Payload**: None (0 bytes)
+
+**Example**: `[0x83] [0x03]`
+
+#### `0x70` / `0x71` / `0x72` / `0x73` — Display Predefined Pattern (mode in low nibble)
+
+Display a panel-flash-stored pattern by index, in one of the four display modes. Predefined patterns are stored in a dedicated flash region (separate from PSRAM) and survive power-cycle. Use cases: error glyphs (slot 0 reserved as canonical error-display glyph), test patterns, calibration patterns, factory-loaded stimuli. Mode semantics follow the v1 default (Oneshot / Triggered / Gated all one-shot, Persistent the special case) — see v1 § Display Mode Summary and the open questions under v1 `0x12` / `0x13`.
+
+| Cmd | Mode | Notes |
+|:-:|:--|:--|
+| `0x70` | Oneshot                | one scan of the predefined pattern, then dark |
+| `0x71` | Persistent             | continuous refresh until next command (special-case exception) |
+| `0x72` | Triggered (one-shot)   | per-edge firing per v1 `0x12`: 20 EINT edges = one frame, then dark |
+| `0x73` | Gated (one-shot)       | output-enable gate per v1 `0x13`: HIGH = LEDs visible, LOW = dark |
+
+**Payload**: 3 bytes — predefined-pattern index (24-bit little-endian) + 1 byte duty_cycle.
+
+**Example**:
 
 ```
-// Send pattern that will be fired on each scanner trigger edge, stretch 5
-[0x03] [0x32] [pattern data: 200 bytes] [0x05]
-// Each rising edge on EINT fires one display unit
+[0x03] [0x70] [0x00 0x00 0x00] [0xC0]    // display predefined pattern 0 (error glyph) at duty_cycle=192, Oneshot
+[0x03] [0x71] [0x01 0x00 0x00] [0xFF]    // display predefined pattern 1 (test pattern) Persistent at full
 ```
 
-**Window-gated PSRAM display** (display while trigger HIGH, off while LOW):
+> **⚠ Open question — Predefined pattern catalog.** Slot count, factory vs. user-installable, programming mechanism (likely reuses the ISP primitives over a different flash region), 2L vs. 16L pattern storage, what happens on display of an unprogrammed slot — all TBD before v3 firmware.
 
-```
-// Pre-load pattern to PSRAM, stretch 5
-[0x02] [0x1F] [0x00 0x00 0x00] [pattern data: 50 bytes] [0x05]
-// Display pattern from PSRAM, gated to EINT HIGH window
-[0x03] [0x54] [0x00 0x00 0x00]
-// Trigger HIGH -> pattern visible
-// Trigger LOW  -> display off
-// Trigger HIGH -> pattern visible again
-// …until new command received
-```
+### Future feature classes (v3 reservation, no opcodes yet)
 
-(The pre-load step uses `0x1F` from v2 with the v3 header byte `[0x03]` — explicit application of the version-superset rule from v2 § Compatibility.)
-
-## v4 — G6 Panel Protocol v4 (deferred)
-
-Version 4 introduces **predefined patterns** stored in panel flash (all-on, checkerboards, etc.) plus stretch on PSRAM-indexed display. Header version bits = `0b0000100` (`0x04` / `0x84`).
-
-**Deferred to future work.** v1+v2+v3 ship first. Open work for v4: per-command spec sections for 7 of 10 commands; the predefined-pattern catalog (slot count, factory vs user-installable, format, programming mechanism — likely reuses the ISP primitives below over a different flash region); alignment to the v3 mode set (current v4 list uses the older Trigger/Gated-Persistent naming; `0x64`/`0x74` slots likely deprecated since Gated-Persistent dropped). Opcodes `0x60`–`0x64` (Display PSRAM Index with Stretch, modes Oneshot/Trigger/Gated/Persistent/Gated-Persistent) and `0x70`–`0x74` (Display Predefined Pattern with Stretch, same modes) are reserved in the namespace. See Master command summary below for the 6 v4 opcodes documented today.
+The remaining `0x20` / `0x40` / `0x80` high-nibble pattern-type ranges are reserved for future grayscale extensions (4-level, 256-level, etc.) using the same low-nibble-mode encoding. Color support, if ever added, would likely claim an additional high-nibble range. No opcode-level detail today.
 
 ## In-System Programming (ISP)
 
@@ -494,74 +560,89 @@ Single firmware image, no bootloader split. If in-firmware ISP gets corrupted mi
 3. **ISP-in-v1 vs separate protocol version.** Putting flash-write opcodes in v1 means every future v2/v3/v4 panel firmware must continue to support them. A dedicated ISP protocol (with explicit `BOOT_TO_ISP` transition) would isolate dangerous operations and survive version evolution better. Current choice favors bring-up simplicity; revisit before stable release.
 4. **Mixed-firmware arenas on partial-flash failure.** Sequential one-at-a-time ISP avoids bus-wide damage but creates mixed-version arenas if a mid-arena panel fails. Audit before experiments.
 
-## v5 — G6 Panel Protocol v5 (sketch only — no specifiable surface)
+## Master command summary
 
-Future-version namespace for additional grayscale levels (`0x20…0x2F` = 4-level, `0x40…0x4F` = 256-level — extending the v1 `0x10` 2-level / `0x30` 16-level encoding pattern), color support, and pattern modifiers. No opcode-level detail today. Roadmap, not a buildable surface.
+Two tables: **Must implement** (v1 firmware ship target) and **Specced, deferred** (v1 Triggered/Gated, all v2, all v3, and ISP).
 
-## Master command summary (v1–v4)
+### Must implement (v1)
 
-This table provides a complete reference of all commands across protocol versions v1–v4.
+| Byte 0 (header) | Byte 1 (cmd) | Bytes 2+ (payload) | Description | Status |
+| :--: | :--: | :-- | :-- | :-- |
+| `0x01` / `0x81` | `0x01` | 200 bytes | Communication check | implemented |
+| `0x01` / `0x81` | `0x10` | 51 bytes (50 pattern + duty_cycle) | Display 2-Level Grayscale (Oneshot) | implemented |
+| `0x01` / `0x81` | `0x11` | 51 bytes (50 pattern + duty_cycle) | Display 2-Level Grayscale (Persistent) | implemented |
+| `0x01` / `0x81` | `0x30` | 201 bytes (200 pattern + duty_cycle) | Display 16-Level Grayscale (Oneshot) | implemented |
+| `0x01` / `0x81` | `0x31` | 201 bytes (200 pattern + duty_cycle) | Display 16-Level Grayscale (Persistent) | implemented |
 
-| Byte 0 (header) | Byte 1 (cmd) | Bytes 2+ (payload) | Description | Protocol version |
-| :--: | :--: | :-- | :-- | :--: |
-| `0x01` / `0x81` | `0x01` | 200 bytes | Communication check | v1 |
-| `0x01` / `0x81` | `0x10` | 51 bytes (50 pattern + stretch) | Display 2-Level Grayscale (Oneshot) | v1 |
-| `0x01` / `0x81` | `0x30` | 201 bytes (200 pattern + stretch) | Display 16-Level Grayscale (Oneshot) | v1 |
-| `0x02` / `0x82` | `0x02` | None | Query diagnostic stats | v2 |
-| `0x02` / `0x82` | `0x03` | None | Reset diagnostic stats | v2 |
-| `0x02` / `0x82` | `0x0F` | None | Reset PSRAM (clear user patterns) | v2 |
-| `0x02` / `0x82` | `0x1F` | 3 idx + 50 pattern + stretch | Write 2-Level Grayscale to PSRAM | v2 |
-| `0x02` / `0x82` | `0x3F` | 3 idx + 200 pattern + stretch | Write 16-Level Grayscale to PSRAM | v2 |
-| `0x02` / `0x82` | `0x50` | 3 idx | Display PSRAM Index (Oneshot) | v2 |
-| `0x03` / `0x83` | `0x12` | 51 bytes (50 pattern + stretch) | Display 2-Level Grayscale (Triggered) | v3 |
-| `0x03` / `0x83` | `0x13` | 51 bytes (50 pattern + stretch) | Display 2-Level Grayscale (Persistent) — *proposed, not implemented* | v3 |
-| `0x03` / `0x83` | `0x14` | 51 bytes (50 pattern + stretch) | Display 2-Level Grayscale (Gated) | v3 |
-| `0x03` / `0x83` | `0x32` | 201 bytes (200 pattern + stretch) | Display 16-Level Grayscale (Triggered) | v3 |
-| `0x03` / `0x83` | `0x33` | 201 bytes (200 pattern + stretch) | Display 16-Level Grayscale (Persistent) — *proposed, not implemented* | v3 |
-| `0x03` / `0x83` | `0x34` | 201 bytes (200 pattern + stretch) | Display 16-Level Grayscale (Gated) | v3 |
-| `0x03` / `0x83` | `0x52` | 3 idx | Display PSRAM Index (Triggered) | v3 |
-| `0x03` / `0x83` | `0x53` | 3 idx | Display PSRAM Index (Persistent) — *proposed, not implemented* | v3 |
-| `0x03` / `0x83` | `0x54` | 3 idx | Display PSRAM Index (Gated) | v3 |
-| `0x04` / `0x84` | `0x60` | 3 idx + stretch | Display PSRAM Index with Stretch (Oneshot) | v4 |
-| `0x04` / `0x84` | `0x62` | 3 idx + stretch | Display PSRAM Index with Stretch (Gated) | v4 |
-| `0x04` / `0x84` | `0x63` | 3 idx + stretch | Display PSRAM Index with Stretch (Persistent) | v4 |
-| `0x04` / `0x84` | `0x70` | 3 idx + stretch | Display Predefined Pattern with Stretch (Oneshot) | v4 |
-| `0x04` / `0x84` | `0x72` | 3 idx + stretch | Display Predefined Pattern with Stretch (Gated) | v4 |
-| `0x04` / `0x84` | `0x73` | 3 idx + stretch | Display Predefined Pattern with Stretch (Persistent) | v4 |
-| `0x01` / `0x81` | `0xE0` | 16-byte sentinel + 4-byte unlock token | `ISP_ENTER` (begin in-system programming session) | v1 (ISP) |
-| `0x01` / `0x81` | `0xE1` | 3 sector + 4 nonce | `ISP_ERASE_SECTOR` | v1 (ISP) |
-| `0x01` / `0x81` | `0xE2` | 3 page + 4 nonce + 256 data + 4 CRC32 | `ISP_WRITE_PAGE` | v1 (ISP) |
-| `0x01` / `0x81` | `0xE3` | 3 start + 3 length + 4 nonce + 4 expected CRC32 | `ISP_VERIFY_CRC` | v1 (ISP) |
-| `0x01` / `0x81` | `0xE4` | 4 nonce + 1 mode | `ISP_EXIT_REBOOT` | v1 (ISP) |
+### Specced, deferred (v1 Triggered/Gated, all v2, all v3, ISP)
 
-(v4 Trigger and Gated-Persistent rows omitted pending alignment to the v3 mode set — see v4 deferred banner. ISP opcodes have extended confirmation slot — see § In-System Programming.)
+v1 Triggered + Gated are prototyped (Triggered measured at 865 ± 17 ns trigger-to-LED latency at 8 kHz on prototype hardware). v2 PSRAM and v3 diagnostics + predefined patterns have open semantic questions that must be resolved before implementation. ISP is a draft pending design review.
 
-**Notes:**
+| Byte 0 (header) | Byte 1 (cmd) | Bytes 2+ (payload) | Description | Version | Review notes |
+| :--: | :--: | :-- | :-- | :--: | :-- |
+| `0x01` / `0x81` | `0x12` | 51 bytes (50 pattern + duty_cycle) | Display 2-Level Grayscale (Triggered) | v1 | prototyped |
+| `0x01` / `0x81` | `0x13` | 51 bytes (50 pattern + duty_cycle) | Display 2-Level Grayscale (Gated) | v1 | prototyped |
+| `0x01` / `0x81` | `0x32` | 201 bytes (200 pattern + duty_cycle) | Display 16-Level Grayscale (Triggered) | v1 | prototyped |
+| `0x01` / `0x81` | `0x33` | 201 bytes (200 pattern + duty_cycle) | Display 16-Level Grayscale (Gated) | v1 | prototyped |
+| `0x02` / `0x82` | `0x0F` | None | Reset PSRAM (clear user patterns) | v2 | |
+| `0x02` / `0x82` | `0x3F` | 3 idx + 200 pattern + duty_cycle | Write 16-Level Grayscale to PSRAM | v2 | ⚠ index semantics open |
+| `0x02` / `0x82` | `0x50` | 3 idx | Display PSRAM Index, implicit duty_cycle (Oneshot) | v2 | |
+| `0x02` / `0x82` | `0x51` | 3 idx | Display PSRAM Index, implicit duty_cycle (Persistent) | v2 | |
+| `0x02` / `0x82` | `0x52` | 3 idx | Display PSRAM Index, implicit duty_cycle (Triggered) | v2 | |
+| `0x02` / `0x82` | `0x53` | 3 idx | Display PSRAM Index, implicit duty_cycle (Gated) | v2 | |
+| `0x02` / `0x82` | `0x60` | 3 idx + duty_cycle | Display PSRAM Index, explicit duty_cycle (Oneshot) | v2 | |
+| `0x02` / `0x82` | `0x61` | 3 idx + duty_cycle | Display PSRAM Index, explicit duty_cycle (Persistent) | v2 | |
+| `0x02` / `0x82` | `0x62` | 3 idx + duty_cycle | Display PSRAM Index, explicit duty_cycle (Triggered) | v2 | |
+| `0x02` / `0x82` | `0x63` | 3 idx + duty_cycle | Display PSRAM Index, explicit duty_cycle (Gated) | v2 | |
+| `0x03` / `0x83` | `0x02` | None | Query diagnostic stats | v3 | ⚠ data shape unspecified |
+| `0x03` / `0x83` | `0x03` | None | Reset diagnostic stats | v3 | |
+| `0x03` / `0x83` | `0x70` | 3 idx + duty_cycle | Display Predefined Pattern (Oneshot) | v3 | ⚠ pattern catalog TBD |
+| `0x03` / `0x83` | `0x71` | 3 idx + duty_cycle | Display Predefined Pattern (Persistent) | v3 | ⚠ pattern catalog TBD |
+| `0x03` / `0x83` | `0x72` | 3 idx + duty_cycle | Display Predefined Pattern (Triggered) | v3 | ⚠ pattern catalog TBD |
+| `0x03` / `0x83` | `0x73` | 3 idx + duty_cycle | Display Predefined Pattern (Gated) | v3 | ⚠ pattern catalog TBD |
+| `0x01` / `0x81` | `0xE0` | 16-byte sentinel + 4-byte unlock token | `ISP_ENTER` (begin in-system programming session) | v1 (ISP) | draft — design review needed |
+| `0x01` / `0x81` | `0xE1` | 3 sector + 4 nonce | `ISP_ERASE_SECTOR` | v1 (ISP) | draft |
+| `0x01` / `0x81` | `0xE2` | 3 page + 4 nonce + 256 data + 4 CRC32 | `ISP_WRITE_PAGE` | v1 (ISP) | draft |
+| `0x01` / `0x81` | `0xE3` | 3 start + 3 length + 4 nonce + 4 expected CRC32 | `ISP_VERIFY_CRC` | v1 (ISP) | draft |
+| `0x01` / `0x81` | `0xE4` | 4 nonce + 1 mode | `ISP_EXIT_REBOOT` | v1 (ISP) | draft |
+
+ISP opcodes use an extended confirmation slot — see § In-System Programming.
+
+**Notes on table columns:**
 
 - **Byte 0 (Header)**: The two values shown (e.g., `0x01` / `0x81`) differ only in the MSB parity bit. The actual value depends on the parity of the entire message.
-- **Protocol Version**: Encoded in bits 0–6 of Byte 0 (`0x01` = v1, `0x02` = v2, `0x03` = v3, `0x04` = v4).
-- **Index**: 24-bit integer (3 bytes) specifying PSRAM or predefined pattern location.
-- **Stretch**: 8-bit value (0–255) for brightness control.
+- **Protocol Version**: encoded in bits 0–6 of byte 0 — `0x01` = v1 live-SPI display, `0x02` = v2 PSRAM-backed display, `0x03` = v3 diagnostics + predefined patterns + future.
+- **Cmd encoding** (display commands): high nibble = pattern type (`1`=2L Grayscale, `3`=16L Grayscale, `5`=PSRAM-indexed [implicit `duty_cycle`], `6`=PSRAM-indexed [explicit `duty_cycle`], `7`=Predefined pattern); low nibble = mode (`0`=Oneshot, `1`=Persistent, `2`=Triggered, `3`=Gated). PSRAM-write (`0x3F`) uses low nibble `F` as the "storage op, not a display mode" marker. Reset commands (`0x0F`, `0x02`, `0x03`) are administrative and don't follow the encoding.
+- **Index**: 24-bit little-endian integer (3 bytes) specifying PSRAM or predefined-pattern location.
+- **`duty_cycle`**: 8-bit value (0–255) for brightness control (see § Duty Cycle Value).
 - **Pattern Data**:
   - 2-level: 50 bytes (1 bit per pixel, 20×20 = 400 pixels)
   - 16-level: 200 bytes (4 bits per pixel, 20×20 = 400 pixels)
 
+### Reserved confirmation values (panel → controller)
+
+These values appear **only in the 3-byte CIPO confirmation slot** (see § Confirmation message) and MUST NOT be issued as controller → panel commands. They are reserved across all protocol versions.
+
+| Cmd byte | Slot encoding | Meaning |
+| :--: | :-- | :-- |
+| `0xFF` | `{header_with_parity, 0xFF, 0x00}` | **COMM_CHECK fail sentinel.** Panel returns this when the most recent valid COMM_CHECK message had a byte-level mismatch against the canonical payload (`payload[i] != i` for some `i ∈ [0, 200)`). Header parity is recomputed over `{version, 0xFF, 0x00}`; checksum byte is `0x00` since the offending message had no valid checksum to echo. |
+
 ### Display Mode Summary
 
-| Mode | Behavior | Use Case | Status |
-| :-- | :-- | :-- | :-- |
-| **Oneshot** | Display pattern once immediately; controller drives every frame | Standard display, frame-by-frame deterministic control | v1, canonical |
-| **Triggered** | Each rising edge on EINT fires one display unit; pattern stays loaded | Sub-frame synchronization (two-photon microscopy resonant scanners, etc.) | v3, prototyped (`G6_Panels_Test_Firmware @ bb26a44`) |
-| **Gated** | While EINT HIGH the panel internally refreshes the loaded pattern; while LOW, off | Window-gated display for behavior-rig event windows | v3 |
-| **Persistent** | Display pattern continuously until next command | Static backgrounds (supplanted by Oneshot-per-frame for determinism) | v3, **proposed, not implemented in initial v3** |
+Modes are encoded in the low nibble of the command byte (`0`=Oneshot, `1`=Persistent, `2`=Triggered, `3`=Gated). The default operating model is **controller-driven, one-shot per command** — Oneshot, Triggered, and Gated all "consume" the pattern on one display unit (one scan, one trigger event, or one gate cycle respectively) and return the panel to dark/idle until the next command. Persistent is the **special-case exception** where the panel keeps refreshing without further commands.
+
+| Low nibble | Mode | Behavior | Use Case | Status |
+| :--: | :-- | :-- | :-- | :-- |
+| `0` | **Oneshot** | One BCM scan on receipt, then dark | Frame-by-frame deterministic control (canonical production case); controller streams one command per stimulus | **v1, implemented** in `feat/v1-stage2-bcm` |
+| `1` | **Persistent** (special case) | Continuous refresh until next display command | Static backgrounds, single-panel bench tests, low-SPI-bandwidth scenarios | **v1, implemented** in `feat/v1-stage2-bcm` |
+| `2` | **Triggered** (one-shot) | Pattern loaded; each EINT rising edge fires one row × 4 bit-planes; **20 edges = one frame consumed → dark**. New pattern mid-consumption overwrites (controller-side responsibility to monitor; warning instrumentation deferred). | Sub-frame synchronization (two-photon microscopy resonant scanners, etc.) | specced; prototyped |
+| `3` | **Gated** (one-shot) | Pattern processing follows normal Oneshot (one scan per command, queue drain-to-latest); EINT is a **global output-enable gate**: HIGH → LEDs visible, LOW → panel dark with queue still building. | Window-gated display for behavior-rig event windows (gate driven by rig clock, decoupled from controller streaming) | v1 specced, prototyped |
 
 ### Protocol Evolution
 
-- **v1**: Basic Oneshot display with stretch (2-level and 16-level grayscale)
-- **v2**: PSRAM storage and indexed display (storage efficiency, fast pattern switching)
-- **v3**: Triggered and Gated display modes (trigger-line synchronization for two-photon microscopy and behavior-rig gating); Persistent reserved but deferred
-- **v4**: Predefined patterns with stretch — deferred to future work; will need re-alignment to v3 mode set
-- **v5**: Additional grayscale levels, color support, pattern modifiers (future)
+- **v1 — Live SPI display**: All four display modes (Oneshot, Persistent, Triggered, Gated) for both 2-level and 16-level grayscale; pattern data on every command. Includes COMM_CHECK and the CIPO 3-byte confirmation slot. Implemented in `reiserlab/LED-Display_G6_Firmware_Panel @ feat/v1-stage1-protocol`: COMM_CHECK + Oneshot + Persistent. Triggered + Gated specced + prototyped in test firmware; not in v1 production firmware yet.
+- **v2 — PSRAM-backed display**: 16-Level pattern storage in panel PSRAM (`0x3F` write, `0x0F` reset); indexed display in all four modes, with two duty_cycle flavors (`0x5x` implicit / `0x6x` explicit). Specced; not implementing now (subject to continued review on PSRAM addressing semantics).
+- **v3 — Everything else**: Diagnostics (`0x02`/`0x03`); panel-flash Predefined Patterns (`0x7x`); placeholder for future grayscale-level / color extensions. Specced; not implementing now.
 
 ---
 
@@ -572,6 +653,19 @@ This table provides a complete reference of all commands across protocol version
 3. **Panel error display command-set decision.** Which errors are most relevant and what command code carries them within the `0xC2`/predefined-pattern-0 framework.
 4. **v3 trigger edge polarity** (from test rig). Firmware code expects rising edge but AD3 + Ch2 captures show LED fires on the **falling edge** of W1 — likely hardware ringing (±2.5 V overshoot). Hypothesis in `G6_Panels_Test_Firmware/single_led/SESSION_2026-04-24_PIOFULL_AD3.md`; not yet fixed.
 
+## Implementation status
+
+v1 panel firmware: [`reiserlab/LED-Display_G6_Firmware_Panel`](https://github.com/reiserlab/LED-Display_G6_Firmware_Panel).
+
+| Spec item | Status |
+| :-- | :-- |
+| Message framing, header byte, parity rule, CIPO 3-byte confirmation slot (4-state encoding, `0xFF` COMM_CHECK-fail sentinel) | implemented (not yet stacked-panel bench-validated) |
+| `0x01` COMM_CHECK (byte-for-byte validation against canonical payload) | implemented |
+| `0x10` / `0x11` 2L Oneshot + Persistent, `0x30` / `0x31` 16L Oneshot + Persistent | implemented |
+| Duty cycle (BCM-via-PIO with fixed-period scan, default 1 kHz refresh) | implemented |
+| `0x12` / `0x13` / `0x32` / `0x33` Triggered + Gated | specced; prototyped on separate test firmware; not in production firmware yet |
+| All v2, v3, and ISP commands | specced; not implemented |
+
 ## Cross-references
 
 - [Source Google Doc, "Panel Version 1" tab](https://docs.google.com/document/d/17crYq4sdD1GhazOPS_Yi6UyGV6ugUy3WGnCWWw49r_0/edit#) — verbatim source for this section.
@@ -580,5 +674,6 @@ This table provides a complete reference of all commands across protocol version
 - [`g6_02-led-mapping.md`](g6_02-led-mapping.md) — panel hardware reference (v0.2 + v0.3) + LED mapping; v0.1 mapping CSV in [`g6_02-led-mapping-v0p1.csv`](g6_02-led-mapping-v0p1.csv).
 - [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md) — host-side panel-block formatting (parity pre-computation), checksum algorithm.
 - [`g6_03-controller.md`](g6_03-controller.md) — controller-side framing, panel-set transmission, command dispatch.
-- [`iorodeo/g6_firmware_devel`](https://github.com/iorodeo/g6_firmware_devel) — authoritative v1 panel firmware (reconciliation pending).
-- [`mbreiser/G6_Panels_Test_Firmware`](https://github.com/mbreiser/G6_Panels_Test_Firmware) — v3 prototype / characterization rig (BCM, gating, trigger latency).
+- [`reiserlab/LED-Display_G6_Firmware_Panel`](https://github.com/reiserlab/LED-Display_G6_Firmware_Panel) — active v1 panel firmware (Reiser Lab fork).
+- [`iorodeo/g6_firmware_devel`](https://github.com/iorodeo/g6_firmware_devel) — baseline upstream of the fork; reference only.
+- [`mbreiser/G6_Panels_Test_Firmware`](https://github.com/mbreiser/G6_Panels_Test_Firmware) — prototype / characterization rig (BCM, gating, trigger latency).

--- a/docs/development/g6_02-led-mapping.md
+++ b/docs/development/g6_02-led-mapping.md
@@ -227,10 +227,6 @@ Worked example consumers: [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) �
 1. **KiCad submodule init for direct hardware audit.** Most firmware-relevant facts already verified via PR-review docs + direct gh-api KiCad trace; init the `Generation 6/Panels` submodule (blocked on SSH host-key trust per handover) when convenient for ongoing iteration.
 2. **Maximum SPI clock rate.** Firmware default is 30 MHz; **target is 25 MHz with margin**, but exact panel-side hardware ceiling is **TBD** (not characterized). Worth measuring on a scope before pushing past 25 MHz on production hardware.
 
-## Historical context (v0.1)
-
-The original v0.1 ("Janelia batch") panel had reversed LED polarity (col LOW + row HIGH = ON) due to LED placement during assembly, and used 240 Ω current-limit resistors. v0.2 fixed both: flipped to NORMAL polarity (col HIGH + row LOW = ON) and switched to 160 Ω resistors (~50 % brightness boost; better uniformity under multi-LED load due to UCC27517's asymmetric output impedance). v0.2 also added the R29 33 Ω MISO series-termination, properly routed EINT to GP45 (no more bodge wire), and shrunk the board to 45×45 mm. v0.3 then redesigned the pin map for clean dual-PIO scanning. **v0.1 is not built today** — kept here as the reference for the LED designator CSV (the geometric mapping is unchanged across all three revisions).
-
 ## Cross-references
 
 - [Source Google Doc, "Panel LED Mappings" tab](https://docs.google.com/document/d/17crYq4sdD1GhazOPS_Yi6UyGV6ugUy3WGnCWWw49r_0/edit#) — v0.1 LED mapping verbatim source.

--- a/docs/development/g6_03-controller.md
+++ b/docs/development/g6_03-controller.md
@@ -63,7 +63,7 @@ Inventory of the slim G4.1 controller used to produce the four classifications b
 | v2 PSRAM workflow + TSI parsing for Mode 1 | Mode 1 absent (`modes.h:6-10`); no PSRAM-related code anywhere | Adds load-phase logic, `(PatternID, FrameIndex16) → PSRAMAddress24` mapping table, TSI 5-byte record parser, DO/AO output drivers (pin assignments depend on arena hardware). |
 | `g6-panel-storage-mode` host command | Not in `ArenaCommands` enum | Pick a free opcode — none of `0x00, 0x01, 0x06, 0x08, 0x16, 0x30, 0x32, 0x66, 0x70, 0xFF` are available. |
 | EINT trigger-line wiring (input GPIO) used by v1 Triggered/Gated | Slim has no input pins beyond CS lines | Single trigger input to be added. Wiring depends on arena hardware. |
-| Magic / format-version field / XOR checksum in pattern header | None in `PatternHeader.h:6-15` | Adopt v2 layout per `g6_04`. |
+| Magic / format-version field / CRC-8 header + per-frame CRC-16 | None in `PatternHeader.h:6-15` | Adopt v2 layout per `g6_04`: CRC-8/AUTOSAR over the 17-byte header (byte 17) + CRC-16/CCITT trailer per frame (see [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § CRC-8 algorithm and [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md) § Frame Format). |
 | Mode 1 (TSI Position Function) and Mode 5 (Streaming) top-level dispatch | Slim implements only Modes 2/3/4 (`modes.h:6-10`); Mode 5 streaming is partially built via `STREAMING_FRAME` state but no top-level mode dispatch | Add full mode dispatch for Modes 1–5. |
 
 **Drop / not needed for G6:**

--- a/docs/development/g6_03-controller.md
+++ b/docs/development/g6_03-controller.md
@@ -1,7 +1,7 @@
 # G6 — Controller (Teensy SW)
 
 Source: G6 panels protocol v1 proposal ([Google Doc `17crYq4s...`](https://docs.google.com/document/d/17crYq4sdD1GhazOPS_Yi6UyGV6ugUy3WGnCWWw49r_0/edit#), tabs "Controller Teensy SW" + "Major updates for v2" + "v3 and onwards…").
-Status: **Draft (v1 spec) + Teaser (v2) + Stub (v3+)**. **No G6 controller firmware exists yet** — all G6-specific behavior below is aspirational. G4.1 slim baseline ([floesche/LED-Display_G4.1_ArenaController_Slim](https://github.com/floesche/LED-Display_G4.1_ArenaController_Slim)) is reconciled into the carry-over / modify / new / drop tables below.
+Status: **Draft (v1 spec) + Teaser (v2) + Stub (v3+)**. **No G6 controller firmware exists yet.** The G4.1 slim baseline ([floesche/LED-Display_G4.1_ArenaController_Slim](https://github.com/floesche/LED-Display_G4.1_ArenaController_Slim)) is the structural starting point; the spec below is the forward-looking G6 surface.
 
 This file describes the host-PC ↔ controller interface and the controller-side responsibilities for slicing, packing, and transmitting frames over SPI to G6 v1 panels. The controller acts as a transport-and-timing engine: it preserves the G4 host command set, loads/streams full arena frames, slices them per panel, encodes G6 v1 panel messages, and transmits them on one or more SPI buses.
 
@@ -9,7 +9,7 @@ This file describes the host-PC ↔ controller interface and the controller-side
 
 ## Current state
 
-There is **no G6 controller firmware** yet. Both candidate G6 panel firmwares ([`iorodeo/g6_firmware_devel`](https://github.com/iorodeo/g6_firmware_devel) for v1 and [`G6_Panels_Test_Firmware`](https://github.com/mbreiser/G6_Panels_Test_Firmware) for the v3 prototype rig) target the panel side, not the controller. The G4 baseline is the **slim G4.1 Arena Controller** ([`LED-Display_G4.1_ArenaController_Slim`](https://github.com/floesche/LED-Display_G4.1_ArenaController_Slim) — PlatformIO Teensy 4.1 project, ~1/4 the LOC of the legacy G4.1 controller, no QP framework). All controller-side claims in this file are reconciled against that codebase.
+There is **no G6 controller firmware** yet. Both candidate G6 panel firmwares ([`iorodeo/g6_firmware_devel`](https://github.com/iorodeo/g6_firmware_devel) for v1 and [`G6_Panels_Test_Firmware`](https://github.com/mbreiser/G6_Panels_Test_Firmware) for the v3 prototype rig) target the panel side, not the controller. The G4 baseline is the **slim G4.1 Arena Controller** ([`LED-Display_G4.1_ArenaController_Slim`](https://github.com/floesche/LED-Display_G4.1_ArenaController_Slim) — PlatformIO Teensy 4.1 project, ~1/4 the LOC of the legacy G4.1 controller, no QP framework).
 
 ### Reconciliation: Controller spec vs G4.1 slim baseline
 
@@ -47,7 +47,7 @@ Inventory of the slim G4.1 controller used to produce the four classifications b
 | SPI framing: emit v1 panel-protocol bytes with parity | `SpiManager::transferPanelSet` (`SpiManager.cpp:70-84`) writes panel buffer raw — no parity computed | Apply the parity ownership rule from [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md) § Panel Block Format: validate parity on SD reads (pre-formatted blocks pass through unchanged in Modes 2/3); recompute parity for any block the controller synthesizes (Modes 4/5, all-on, all-off, error displays, ISP). |
 | Pattern header: G4 has 7-byte/8-byte union → G6 needs 18-byte v2 header | `PatternHeader.h:6-15`, `constants.h:100` (`pattern_header_size = 7`) | Adopt the 18-byte v2 layout from [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md): G6PT magic + version + Arena/Observer IDs + frame count + row/col counts + gs_val + panel mask + checksum. **Use a plain `uint8_t[18]` array with explicit byte-by-byte access** rather than a bit-packed struct/union — the G4.1 slim baseline's `uint64_t` union without `__attribute__((packed))` is fragile across compilers. Parsing should be one explicit `if/switch` per field, not pointer-casting. |
 | CS-line count and pin matrix | Hard-coded 5×6 GPIO map for G4.1 wiring in `panel_set_select_pins[5][6]` (`constants.h:77-83`); `region_count_per_frame=2` (`constants.h:68`) | Re-wire for G6 arena (`Generation 6/Arena/` `v1.1.7` production); count and per-row count depend on arena geometry. |
-| `fillBufferAllOn` stretch values (1 grayscale, 50 binary) | `SpiManager.cpp:170-193` | Re-derive for G6 panel-protocol v1 stretch semantics. |
+| `fillBufferAllOn` duty_cycle values (1 grayscale, 50 binary) | `SpiManager.cpp:170-193` | Re-derive for G6 panel-protocol v1 duty_cycle semantics. |
 | `STREAM_FRAME_CMD` payload size | `CommandProcessor.cpp:140-190`: 7-byte header + frame data; `analog_x`/`analog_y` bytes parsed and logged but unused | G6 frame data sizes differ (binary 51 B/panel × N or grayscale 201 B/panel × N at panel level; on-disk panel block 53/203 — pick which the wire format uses). Decide whether `analog_x`/`analog_y` survive G4→G6. |
 | Refresh-rate defaults (300 Hz greenscale / 1000 Hz binary) | `constants.h:122-123` | Reconcile with G6 panel BCM/bit-plane timing budgets — currently unmeasured. |
 | `TRIAL_PARAMS_CMD` (0x08) payload (12 param bytes) | `CommandProcessor.cpp:83-115` | G6 may need an extra byte (panel-mask override or trigger config). |
@@ -62,7 +62,7 @@ Inventory of the slim G4.1 controller used to produce the four classifications b
 | Controller-side parity computation | Not present | See Modify section above. |
 | v2 PSRAM workflow + TSI parsing for Mode 1 | Mode 1 absent (`modes.h:6-10`); no PSRAM-related code anywhere | Adds load-phase logic, `(PatternID, FrameIndex16) → PSRAMAddress24` mapping table, TSI 5-byte record parser, DO/AO output drivers (pin assignments depend on arena hardware). |
 | `g6-panel-storage-mode` host command | Not in `ArenaCommands` enum | Pick a free opcode — none of `0x00, 0x01, 0x06, 0x08, 0x16, 0x30, 0x32, 0x66, 0x70, 0xFF` are available. |
-| v3 trigger-line wiring (input GPIO) | Slim has no input pins beyond CS lines | Single trigger input to be added. Wiring depends on arena hardware. |
+| EINT trigger-line wiring (input GPIO) used by v1 Triggered/Gated | Slim has no input pins beyond CS lines | Single trigger input to be added. Wiring depends on arena hardware. |
 | Magic / format-version field / XOR checksum in pattern header | None in `PatternHeader.h:6-15` | Adopt v2 layout per `g6_04`. |
 | Mode 1 (TSI Position Function) and Mode 5 (Streaming) top-level dispatch | Slim implements only Modes 2/3/4 (`modes.h:6-10`); Mode 5 streaming is partially built via `STREAMING_FRAME` state but no top-level mode dispatch | Add full mode dispatch for Modes 1–5. |
 
@@ -70,9 +70,9 @@ Inventory of the slim G4.1 controller used to produce the four classifications b
 
 | Item | Slim source | Rationale |
 |---|---|---|
-| `DISPLAY_RESET_CMD` (0x01) "reset to FPGA" semantics | `CommandProcessor.cpp:53-55` (already a no-op string-only response) | No FPGA in Teensy slim path; spec § 7 explicitly says drop. |
+| `DISPLAY_RESET_CMD` (0x01) "reset to FPGA" semantics | `CommandProcessor.cpp:53-55` | No FPGA in Teensy slim path; spec § 7 explicitly says drop. |
 | `SWITCH_GRAYSCALE_CMD` (0x06) | `commands.h:9`, `CommandProcessor.cpp:57-69` | Spec § 7 explicitly says drop. May reconsider if G6 ergonomics need it. |
-| `frame_count_y` field of `PatternHeader` | `PatternHeader.h:9` (declared but never read or validated) | Dead weight; bytes reused in v2 layout. |
+| `frame_count_y` field of `PatternHeader` | `PatternHeader.h:9` | Dead weight; bytes reused in v2 layout. |
 | `row_signifier` byte between panel rows in pattern files | `SpiManager.cpp:113` (`++pos;` skips it) | Vestigial padding; v2 pattern files (`g6_04`) drop it. |
 
 (See § Timing measurements still needed (G6 bring-up) at the bottom for the SPI/BCM/Ethernet-RTT numbers `timing.md` does NOT cover.)
@@ -114,7 +114,7 @@ Each stored pattern may be:
 
 The controller uses the frame index from G4 commands to select which arena frame to load and display.
 
-**Block-size composition:** the on-disk panel block is 53 bytes (GS2) / 203 bytes (GS16) = 1-byte panel-protocol header + 1-byte command + pixel data + 1-byte stretch (canonical per [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md)). Section 3 below uses 51 / 201 to refer to *just* pixel data + stretch — same panels, different abstraction layer.
+**Block-size composition:** the on-disk panel block is 53 bytes (GS2) / 203 bytes (GS16) = 1-byte panel-protocol header + 1-byte command + pixel data + 1-byte duty_cycle (canonical per [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md)). Section 3 below uses 51 / 201 to refer to *just* pixel data + duty_cycle — same panels, different abstraction layer.
 
 ### 3. Frame Slicing
 
@@ -125,11 +125,11 @@ For each frame update, the controller must:
 1. Slice the full arena frame into 20×20 subframes, one per panel.
 2. Use Panel Mask in the Pattern Header to determine which panels are being sent (for v1 implementation, it will be fine to assume all panels are present, sending pattern data to all).
 3. Pack each subframe into the G6 v1 pixel formats:
-   - 51 bytes for 2-level (1 bit/pixel) + stretch
-   - 201 bytes for 16-level (4 bits/pixel) + stretch
+   - 51 bytes for 2-level (1 bit/pixel) + duty_cycle
+   - 201 bytes for 16-level (4 bits/pixel) + duty_cycle
 4. Send each subframe to the appropriate panel using G6 v1 oneshot commands.
 
-(51 / 201 = pixel data + stretch byte. The on-disk panel block in Section 2 is 2 bytes larger because it also carries the panel-protocol header + command bytes.)
+(51 / 201 = pixel data + duty_cycle byte. The on-disk panel block in Section 2 is 2 bytes larger because it also carries the panel-protocol header + command bytes.)
 
 ### 4. Panel Routing (Panel Map)
 
@@ -172,9 +172,9 @@ Mode 4 is the lowest priority, with some final details depending on arena hardwa
 
 ### 7. Utility Commands
 
-- **`all-on`** (`0x01, 0xff`) and **`all-off`** (`0x01, 0x00`) — both implemented as carry-overs from slim G4.1. Useful for arena bring-up and host-facing diagnostic ergonomics. Internally `all-off` collapses to the same `ALL_OFF` state as `stop-display`; the duplication is for host clarity, not for distinct internal semantics.
-- **`stop-display`**, **`set-refresh-rate`**, **`get-ethernet-ip-address`** — implemented as in G4.1.
-- **`switch-grayscale`** (0x06) and **`display-reset`** (0x01) — **dropped for G6.** `display-reset` was already a no-op in slim G4.1 (`CommandProcessor.cpp:53-55`); `switch-grayscale` was functional but is supplanted by the canonical pattern-header `gs_val` byte (per [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md)). Hosts will not send these opcodes for G6.
+- **`all-on`** (`0x01, 0xff`) and **`all-off`** (`0x01, 0x00`) — controller-side opcodes for arena bring-up and host-facing diagnostic ergonomics. Internally `all-off` collapses to the same `ALL_OFF` state as `stop-display`; the duplication is for host clarity, not for distinct internal semantics.
+- **`stop-display`**, **`set-refresh-rate`**, **`get-ethernet-ip-address`** — standard G4-compatible host commands.
+- **`switch-grayscale`** (0x06) and **`display-reset`** (0x01) — **dropped for G6.** The canonical pattern-header `gs_val` byte (per [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md)) replaces `switch-grayscale`; `display-reset` has no G6 meaning. Hosts will not send these opcodes for G6.
 
 ---
 
@@ -188,15 +188,15 @@ This is a copy of the G4.1 commands. Possibly adjust for G6 use.
 | Set-frame-position | `0x03, 0x70` | v1 | |
 | Stream-Frame | `0x32` | v1 | G6 frame-data length differs (see below) |
 | Stop-Display | `0x01, 0x30` | v1 | Also doubles as "all off" |
-| all-on | `0x01, 0xff` | v1 | Carry over from slim G4.1 (host-composed via Mode 5 is also possible but `0xff` opcode stays canonical for arena bring-up) |
-| all-off | `0x01, 0x00` | v1 | Carry over from slim G4.1 (same rationale as all-on) |
-| Set-refresh-rate | `0x03, 0x16` | v1 | Sets SPI re-transmission rate. **Default depends on `gs_val` from the loaded pattern** — slim G4.1 picks 300 Hz for grayscale (GS16) and 1000 Hz for binary (GS2); G6 inherits the same defaults but reads `gs_val` from the v2 pattern header instead of the dropped `switch-grayscale` opcode. Host can override via this command. (Note: G6 uses **"grayscale"** terminology consistently; the slim G4.1 "greenscale" name is rebranded here.) |
-| Get-ethernet-ip-address | `0x01, 0x66` | v1 | Returns DHCP-resolved IP as ASCII (matches slim G4.1) |
-| Get-controller-info | `0x01, 0x67` | v1 (G6-new) | Returns `{version, capability_bitmap}` with version-dispatched payload — covers v1 G6-mode detection AND v2 capability detection (Local Storage, Mode 1 TSI, v3 triggered/gated, …). |
+| all-on | `0x01, 0xff` | v1 | Controller-side opcode for arena bring-up. Host-composed Mode 5 frames are also possible, but `0xff` stays canonical for diagnostics. |
+| all-off | `0x01, 0x00` | v1 | Controller-side opcode for arena bring-up (same rationale as all-on). |
+| Set-refresh-rate | `0x03, 0x16` | v1 | Sets SPI re-transmission rate. **Default is picked from the v2 pattern-header `gs_val` byte**: 300 Hz for GS16, 1000 Hz for GS2. Host may override via this command. |
+| Get-ethernet-ip-address | `0x01, 0x66` | v1 | Returns DHCP-resolved IP as ASCII. |
+| Get-controller-info | `0x01, 0x67` | v1 (G6-new) | Returns `{version, capability_bitmap}` with version-dispatched payload — covers v1 G6-mode detection AND v2 capability detection (Local Storage, Mode 1 TSI, v1 Triggered/Gated, …). |
 | g6-panel-storage-mode | `0x02, 0x40, mode_byte` | v2 (G6-new) | Switches controller from SD Mode (`mode_byte = 0`) to Local Storage Mode (`mode_byte = 1`); triggers the load phase that copies SD patterns into panel PSRAM. |
 | g6-program-panel | `0x02, 0x41, panel_index, filename[32]` | v2 (G6-new) | Reflash panel `panel_index` from `/firmware/<filename>` on SD. See § Panel firmware update (ISP). |
 
-**Stream-Frame for G6:** uses a **3-byte stream header** `[0x32, len_lo, len_hi, ...]`. The slim G4.1's `analog_x` / `analog_y` bytes (4 bytes after `len`) are **dropped for G6** (parsed and logged in slim but never plumbed; experimenters with motion-offset needs use Mode 4 closed-loop or a separate AI-driven workflow). Frame-data bytes follow `frame_size = 4 + (num_panels × block_size)` with `block_size = 53` (GS2) or `203` (GS16). For a 2×10 G6 arena: 1064 B (GS2) / 4064 B (GS16) of frame data plus the 3-byte stream header.
+**Stream-Frame for G6:** uses a **3-byte stream header** `[0x32, len_lo, len_hi, ...]`. The legacy `analog_x` / `analog_y` bytes are **not used in G6** — experimenters with motion-offset needs use Mode 4 closed-loop or a separate AI-driven workflow. Frame-data bytes follow `frame_size = 4 + (num_panels × block_size)` with `block_size = 53` (GS2) or `203` (GS16). For a 2×10 G6 arena: 1064 B (GS2) / 4064 B (GS16) of frame data plus the 3-byte stream header.
 
 ---
 
@@ -300,17 +300,18 @@ Mode 1 is invalid in SD Mode.
     - other …
 - To make this error visible — we will need to keep them displayed for a short interval, at least 500 ms. This feature is not required for protocol v1 compliance but provides a quick, hardware-level diagnostic without needing extensive debugging.
 
-**Implementation path for the error display (recommended):** compose the error pattern controller-side as a 20×20 subframe and send to all panels via the existing `0x30` SetFrame command — works on v1 panel firmware today, no panel-firmware changes needed. The v4/v5 predefined-pattern flash mechanism the source spec implies does **not** exist in any firmware (confirmed via [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) v4/v5 reconciliation).
+**Implementation path for the error display (recommended):** compose the error pattern controller-side as a 20×20 subframe and send to all panels via the existing `0x30` SetFrame command — works on v1 panel firmware today, no panel-firmware changes needed. The v3 predefined-pattern flash mechanism (`0x7x`) does **not** exist in any firmware yet.
 
 ---
 
-## v3 controller scope
+## Controller scope for Triggered/Gated, v2 PSRAM, and v3
 
-v1, v2, and v3 are being designed together. Controller changes for v3 are minimal: the v3 panel commands (Triggered / Gated variants for 2-Level / 16-Level / PSRAM-Index pattern types — see [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § v3) need a corresponding controller dispatcher, but most of the existing v1/v2 transport logic carries over unchanged. Persistent-mode opcodes (`0x13`, `0x33`, `0x53`) are reserved in the spec but not implemented in initial v3 — controller doesn't need to dispatch them yet. Specific controller-side additions:
+v1, v2, and v3 are being designed together. Controller-side additions across the three versions:
 
-- Recognize v3 header byte `[0x03]`/`[0x83]` and route to v3 command handlers (alongside v1/v2 handlers per the version-superset rule). Active opcodes: `0x12`/`0x14`/`0x32`/`0x34`/`0x52`/`0x54` (Triggered + Gated, 6 commands).
-- Forward the EINT line state to panels — for the production `arena_10-10`, the wiring runs through the `arena_10-10` jumper J30 (default OPEN per `g6_07-arena-firmware-interface.md`), so the controller drives `TNY.EINT` (Teensy D33) based on whatever software policy the v3 trigger-mode design specifies.
-- v4 (predefined patterns + stretch) is deferred to future work — see [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § v4.
+- **v1 Triggered/Gated** (`0x12`/`0x13`/`0x32`/`0x33` under header `0x01`/`0x81`) — dispatch alongside the v1 Oneshot/Persistent handlers. v1 Persistent (`0x11`/`0x31`) is already implemented in panel firmware; Triggered/Gated are specced and prototyped but not in v1 production firmware yet. See [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § `0x12`/`0x13` for semantics.
+- **v2 PSRAM Triggered/Gated** (`0x52`/`0x53` implicit-`duty_cycle`, `0x62`/`0x63` explicit-`duty_cycle`) — add when v2 firmware lands. `0x53` PSRAM-Persistent is the one Persistent-mode opcode that's reserved-but-deferred (v1 Persistent `0x11`/`0x31` is already live; PSRAM-Persistent depends on v2 PSRAM addressing semantics being resolved first).
+- **v3 dispatcher** — recognize v3 header byte `[0x03]`/`[0x83]` and route to v3 command handlers (diagnostics `0x02`/`0x03`, predefined-pattern display `0x70`–`0x73`) alongside the v1/v2 handlers per the version-superset rule (a v3 panel MUST accept v1 + v2 commands).
+- **EINT forwarding** — Triggered/Gated rely on EINT. For the production `arena_10-10`, the wiring runs through jumper J30 (default OPEN per [`g6_07-arena-firmware-interface.md`](g6_07-arena-firmware-interface.md)), so the controller drives `TNY.EINT` (Teensy D33) based on whatever Triggered/Gated software policy is in force.
 
 ---
 
@@ -332,7 +333,7 @@ The controller reflashes panel firmware over SPI one panel at a time. Panel-side
 
 Sequential, one panel at a time — no parallel ISP across buses. On any failure the controller aborts, reports the failed `panel_index` and the last successful step; remaining panels are not auto-attempted.
 
-ISP primitives may be reused for v4's deferred predefined-pattern programming mechanism (separate flash region).
+ISP primitives may be reused for v3's deferred predefined-pattern programming mechanism (separate flash region).
 
 ---
 
@@ -354,10 +355,9 @@ Slim G4.1 baseline numbers (for reference, not G6 targets): SD reads ~2 µs cach
 
 ## Open Questions / TBDs
 
-1. **No G6 controller firmware exists.** All G6-specific behavior here is aspirational. Slim G4.1 baseline (`8f1029f`) is reconciled into the carry-over / modify / new / drop tables in Current state. Next phase: build G6 controller against those tables.
-2. **`all-on` semantics in v2 + Local Storage Mode.** Decision: build a one-shot all-on subframe controller-side (matches v1 behavior); no separate "all-on" PSRAM index opcode in v2. Status note for firmware bring-up.
-3. **`SET_REFRESH_RATE_CMD` (0x16) upper bound** for G6 — slim accepts any `uint16_t` Hz. G6 panel BCM may impose a hard ceiling the controller should enforce. Needs G6-side measurement.
-4. **Per-version command-carry-over scope** — the v2/v3 superset rule (per [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md)) implies higher-version panels accept lower-version commands. Reviewing whether all of slim G4.1's carry-over candidates truly need to be supported in G6 v2/v3 panels (vs. left for the controller alone). Defer until v2 panel firmware exists.
+1. **`all-on` semantics in v2 + Local Storage Mode.** Decision: build a one-shot all-on subframe controller-side (matches v1 behavior); no separate "all-on" PSRAM index opcode in v2. Status note for firmware bring-up.
+2. **`SET_REFRESH_RATE_CMD` (0x16) upper bound** for G6 — accepts any `uint16_t` Hz today; G6 panel BCM may impose a hard ceiling the controller should enforce. Needs G6-side measurement.
+3. **Per-version command-carry-over scope** — the v2/v3 superset rule (per [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md)) implies higher-version panels accept lower-version commands. Reviewing whether all carry-over candidates truly need to be supported in G6 v2/v3 panels (vs. left for the controller alone). Defer until v2 panel firmware exists.
 
 ---
 
@@ -371,4 +371,4 @@ Slim G4.1 baseline numbers (for reference, not G6 targets): SD reads ~2 µs cach
 - [`g6_02-led-mapping.md`](g6_02-led-mapping.md) — pixel ↔ LED designator mapping (host-side concern; the controller treats the 20×20 grid as an opaque 51-byte/201-byte payload).
 - [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md) — on-disk pattern file format (the controller's SD reader consumes these).
 - [`g6_06-host-software.md`](g6_06-host-software.md) — host-side workflow (the producer of the commands listed in Host Command Summary above).
-- [floesche/LED-Display_G4.1_ArenaController_Slim](https://github.com/floesche/LED-Display_G4.1_ArenaController_Slim) — G4 baseline controller implementation. The reconciliation pass (next commit) will diff this verbatim spec against that codebase and produce explicit carry-over / modify / new / drop labels per requirement.
+- [floesche/LED-Display_G4.1_ArenaController_Slim](https://github.com/floesche/LED-Display_G4.1_ArenaController_Slim) — G4 baseline controller implementation; structural starting point for G6 controller work.

--- a/docs/development/g6_04-pattern-file-format.md
+++ b/docs/development/g6_04-pattern-file-format.md
@@ -32,7 +32,7 @@ PAT file
 | 9 | Column Count | uint8 | 1–255 | **Full** grid columns in arena (subset installed via panel mask) |
 | 10 | `gs_val` | uint8 | 1 = GS2, 2 = GS16 | Pixel encoding throughout file |
 | 11–16 | Panel Mask | 6 bytes | bitmask | Which panel positions are physically present (up to 48 panels) |
-| 17 | Checksum | uint8 | 0–255 | XOR of all frame data bytes |
+| 17 | Header CRC | uint8 | 0–255 | CRC-8/AUTOSAR of header bytes 0-16 (per [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § CRC-8 algorithm). Frame-data integrity is handled separately by per-frame CRC-16 trailers (see § Frame Format). |
 
 ### Arena ID and Observer ID
 
@@ -49,28 +49,49 @@ Compact bitmask indicating which panel positions are physically present:
 
 **Validation:** Controller MUST verify (a) `row_count × col_count ≤ 48`, and (b) the count of bits set in the mask is ≤ `row_count × col_count`. If either check fails, return a "pattern error" to the host.
 
-### Checksum (Byte 17)
+### Header CRC (Byte 17)
 
-- **Algorithm**: byte-wise XOR
-- **Computation**: `checksum = byte[0] ^ byte[1] ^ … ^ byte[n]`
-- **Scope**: All frame data (from first frame's `"FR"` magic through last panel's duty_cycle byte)
+- **Algorithm**: CRC-8/AUTOSAR (see [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § CRC-8 algorithm for parameters, test vectors, and bit ordering)
+- **Scope**: header bytes 0-16 only. Frame-data integrity is the job of the per-frame CRC-16 trailers described in § Frame Format.
 - **Result**: single byte (0–255)
-- **Usage**: optional validation in v1 panel protocol; enables future error detection
-
-**💡 Note — two checksum algorithms in the protocol family.** Pattern file uses **XOR**; panel-confirmation message uses **additive sum mod 256** (per [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § Confirmation message). Both intentional, both confirmed against firmware — listed here so readers don't conflate them.
+- **Usage**: required integrity check on the file header. Controller MUST verify on SD read and refuse to open the file on mismatch. Catches header-level bit-flips (`G6PT` magic + sanity rules already cover gross corruption; this is the bit-level defense for fields like `panel_mask` where a single-bit flip might pass the popcount validation).
 
 ## Frame Format
 
-Each frame begins with a 4-byte validation header, followed by all panel blocks for that frame in row-major panel order:
+Each frame begins with a 4-byte validation header, followed by all panel blocks for that frame in row-major panel order, then a 2-byte CRC-16 trailer:
 
 ```
 Frame:
   [Magic: "FR" (0x46 0x52): 2 bytes]
   [Frame Index: uint16 LE: 2 bytes]
   [Panel blocks for all panels, row-major order: panels 0, 1, 2, …, num_panels-1]
+  [CRC-16/CCITT: 2 bytes, little-endian]
 ```
 
-**Frame overhead:** 4 bytes per frame.
+**Frame overhead:** 6 bytes per frame (2 magic + 2 index + 2 CRC).
+
+### Per-frame CRC-16
+
+| Parameter | Value |
+| :-- | :-- |
+| Polynomial | `0x1021` (CRC-16/CCITT-FALSE) |
+| Initial value | `0xFFFF` |
+| Input reflection | false |
+| Output reflection | false |
+| Final XOR | `0x0000` |
+| Universal check value | `0x29B1` over the ASCII string `"123456789"` |
+
+**Scope:** `{FR_magic, frame_index, all_panel_blocks}` — everything in the frame except the CRC-16 trailer itself. CRC bytes are appended little-endian (byte 0 = low 8 bits, byte 1 = high 8 bits).
+
+**Detection at G6 frame sizes:**
+- GS2 frame (1064 B = 8512 bits): HD=4 — catches all 3-bit errors.
+- GS16 frame (4064 B = 32512 bits): HD=4 at the boundary.
+- 3×12 GS16 frame (7312 B = 58496 bits): HD=3 above the 32-kbit HD=4 limit.
+- 16-bit burst-detection floor across all frame sizes.
+
+**Validation policy:** controller computes CRC-16 as each frame is read; on mismatch, the controller MUST refuse to display that frame and report a frame-level pattern error to the host. Localized detection lets the controller skip/retry a single bad frame instead of binning the whole file.
+
+**Reference implementations:** Linux kernel `lib/crc-ccitt.c`, Boost.CRC `crc_16_ccitt_false_t`, Python `crcmod` (poly `0x11021`).
 
 ### Panel ordering
 
@@ -119,8 +140,8 @@ This matches [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § Pixel Data 
 
 ```
 file_size  = 18 + (num_frames × frame_size)
-frame_size = 4 + (num_panels × block_size)
-num_panels = row_count × col_count        # full grid; subset selected via panel mask
+frame_size = 4 + (num_panels × block_size) + 2  # +2 for CRC-16 trailer
+num_panels = row_count × col_count              # full grid; subset selected via panel mask
 block_size = 53 (GS2) or 203 (GS16)
 ```
 
@@ -128,18 +149,19 @@ block_size = 53 (GS2) or 203 (GS16)
 
 | Arena | Frames | Mode | Frame size | File size |
 |---|---:|---|---:|---:|
-| 2×10 (20 panels) | 100 | GS2 | 1,064 B | **106,418 B** (~104 KB) |
-| 2×10 (20 panels) | 100 | GS16 | 4,064 B | **406,418 B** (~397 KB) |
-| 3×12 (36 panels) | 1,000 | GS16 | 7,312 B | **7,312,018 B** (~6.97 MB) |
+| 2×10 (20 panels) | 100 | GS2 | 1,066 B | **106,618 B** (~104 KB) |
+| 2×10 (20 panels) | 100 | GS16 | 4,066 B | **406,618 B** (~397 KB) |
+| 3×12 (36 panels) | 1,000 | GS16 | 7,314 B | **7,314,018 B** (~6.97 MB) |
 
 ## Validation Layers
 
-Four independent validation mechanisms (all **optional** in v1 — present in the format, enforcement is implementation-dependent):
+Five validation mechanisms. The two CRCs are **required** (controller refuses to display on mismatch); the others are catch-all sanity checks:
 
 1. **Pattern magic** (bytes 0–3): `"G6PT"` identifies file type.
-2. **Checksum** (byte 17): XOR of all frame data detects corruption.
-3. **Frame magic** (per frame): `"FR"` + index validates frame boundaries.
-4. **Panel parity** (per block): header byte bit 7 detects transmission errors.
+2. **Header CRC-8** (byte 17): CRC-8/AUTOSAR over the 17-byte header. Required — catches header-level bit-flips before any frame is read.
+3. **Per-frame CRC-16** (2-byte trailer per frame): CRC-16/CCITT over the frame body. Required — localizes corruption to specific frames.
+4. **Frame magic** (per frame): `"FR"` + index validates frame boundaries.
+5. **Panel parity** (per block): header byte bit 7 detects transmission errors at the panel-block level.
 
 ## Controller Operation
 
@@ -149,11 +171,13 @@ Four independent validation mechanisms (all **optional** in v1 — present in th
 2. Validate magic `"G6PT"` and version (= 2 in v2).
 3. Extract `frame_count`, `row_count`, `col_count`, `gs_val`, `panel_mask`, Arena ID, Observer ID.
 4. Verify `row_count × col_count ≤ 48`.
-5. (Optional) Compute and verify checksum over frame data.
+5. Compute and verify the **header CRC-8** over bytes 0-16; on mismatch, return a "header error" to the host and refuse to open the file.
 6. For each frame:
    - Read frame magic `"FR"` and `frame_index` (4 bytes).
    - (Optional) Verify `frame_index` matches the expected sequence value.
    - Read all panel blocks sequentially.
+   - Read the 2-byte CRC-16 trailer.
+   - Compute and verify **CRC-16/CCITT** over `{FR_magic, frame_index, panel_blocks}`; on mismatch, return a frame-level "pattern error" to the host and skip this frame.
    - For each panel block: (optional) validate parity in header byte, then transmit entire block (53 or 203 bytes) directly to the panel via SPI.
 
 ### Transmission
@@ -173,9 +197,9 @@ The PC host (MATLAB / Python / web) generates pattern files:
    - Insert header byte (`0x01` or `0x81`) and command byte (`0x10` GS2 / `0x30` GS16).
    - Pack pixels per G6 panel format (row-major, MSB-first, bottom-left origin; flip MATLAB row → panel row via `row_from_bottom = 19 - row`).
    - Append duty_cycle value.
-4. **Frame assembly**: prepend `"FR"` magic and frame index to panel blocks.
-5. **Checksum**: compute XOR over all frame data, store in header byte 17.
-6. **File writing**: 18-byte header followed by all frames.
+4. **Frame assembly**: prepend `"FR"` magic and frame index to panel blocks; append 2-byte CRC-16/CCITT trailer over `{FR_magic, frame_index, panel_blocks}` little-endian.
+5. **Header CRC**: compute **CRC-8/AUTOSAR** (per [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § CRC-8 algorithm) over header bytes 0-16, store in byte 17.
+6. **File writing**: 18-byte header (including byte-17 CRC) followed by all frames (each with trailing CRC-16).
 
 Cross-reference: [`Generation 6/maDisplayTools/docs/patterns.md`](../../Generation%206/maDisplayTools/docs/patterns.md) for user-facing docs on where generated `.pat` files live and how to regenerate reference patterns.
 

--- a/docs/development/g6_04-pattern-file-format.md
+++ b/docs/development/g6_04-pattern-file-format.md
@@ -7,7 +7,6 @@ Status: **v2 canonical** — 18-byte header, written by [`maDisplayTools/g6/g6_s
 
 - Files **written** today by `maDisplayTools` and `webDisplayTools` use the v2 18-byte header and have a shared bit-level test vector set in [`g6_encoding_reference.json`](../../Generation%206/maDisplayTools/g6/g6_encoding_reference.json).
 - Files **read** today: nothing — there's no consumer until a G6 controller firmware ships.
-- The G4.1 slim controller ([`PatternHeader.h`](https://github.com/floesche/LED-Display_G4.1_ArenaController_Slim/blob/main/src/PatternHeader.h)) has its own 8-byte `PatternHeader` union — that reads G4 patterns, **not** G6 `.pat` files. Documented here so the controller doc work doesn't accidentally treat it as the G6 reader.
 
 ---
 
@@ -35,6 +34,10 @@ PAT file
 | 11–16 | Panel Mask | 6 bytes | bitmask | Which panel positions are physically present (up to 48 panels) |
 | 17 | Checksum | uint8 | 0–255 | XOR of all frame data bytes |
 
+### Arena ID and Observer ID
+
+Both are 6-bit, per-generation namespaces resolved by the [maDisplayTools arena registry](../../Generation%206/maDisplayTools/configs/arena_registry/README.md): Arena ID 1–10 lab / 11–50 community / 51–62 user / 63 reserved; Observer ID 1–20 lab / 21–50 community / 51–62 user / 63 reserved. **Observer ID is host-side metadata only — the controller does not interpret it**; it identifies the observer perspective a pattern was rendered for, supporting one pattern × many perspectives in a library.
+
 ### Panel Mask (Bytes 11–16)
 
 Compact bitmask indicating which panel positions are physically present:
@@ -50,7 +53,7 @@ Compact bitmask indicating which panel positions are physically present:
 
 - **Algorithm**: byte-wise XOR
 - **Computation**: `checksum = byte[0] ^ byte[1] ^ … ^ byte[n]`
-- **Scope**: All frame data (from first frame's `"FR"` magic through last panel's stretch byte)
+- **Scope**: All frame data (from first frame's `"FR"` magic through last panel's duty_cycle byte)
 - **Result**: single byte (0–255)
 - **Usage**: optional validation in v1 panel protocol; enables future error detection
 
@@ -81,13 +84,13 @@ Panel blocks are **pre-formatted for SPI transmission** following G6 Panel Proto
 [Header byte: 1 byte]         ← Protocol v1 (0x01 or 0x81 with parity)
 [Command byte: 1 byte]        ← 0x10 (GS2) or 0x30 (GS16)
 [Pixel data: 50 (GS2) or 200 (GS16) bytes]   ← Row-major, MSB-first packing, origin at bottom-left
-[Stretch: 1 byte]             ← Brightness/timing (0–255)
+[duty_cycle: 1 byte]          ← Brightness scale (0–255); see g6_01 § Duty Cycle Value
 ```
 
 ### Block sizes
 
-- **GS2**: 53 bytes total (1 header + 1 command + 50 pattern + 1 stretch)
-- **GS16**: 203 bytes total (1 header + 1 command + 200 pattern + 1 stretch)
+- **GS2**: 53 bytes total (1 header + 1 command + 50 pattern + 1 duty_cycle)
+- **GS16**: 203 bytes total (1 header + 1 command + 200 pattern + 1 duty_cycle)
 
 The header byte includes parity bit (bit 7) and protocol version (bits 0–6). **Parity ownership rule:** each entity that *sends* a panel block must ensure parity is correct; each entity that *receives* one must validate parity and drop on mismatch. Concretely:
 
@@ -138,9 +141,7 @@ Four independent validation mechanisms (all **optional** in v1 — present in th
 3. **Frame magic** (per frame): `"FR"` + index validates frame boundaries.
 4. **Panel parity** (per block): header byte bit 7 detects transmission errors.
 
-## Controller Operation (aspirational; no G6 controller firmware exists yet)
-
-This section describes how a G6 controller will read pattern files when one is built. The G4.1 slim controller (`floesche/LED-Display_G4.1_ArenaController_Slim`) reads G4 patterns, not G6 `.pat` files. The controller-spec work continues in [`g6_03-controller.md`](g6_03-controller.md).
+## Controller Operation
 
 ### Reading pattern files
 
@@ -157,7 +158,7 @@ This section describes how a G6 controller will read pattern files when one is b
 
 ### Transmission
 
-For Modes 2 and 3 (pre-formatted blocks loaded from `.pat` on SD), the controller transmits panel blocks **without modification**: enable chip-select for the panel, clock out the entire panel block (`header + command + pixels + stretch`), repeat for all panels in the panel set, disable chip-select. Pre-formatted blocks eliminate per-frame parity calculation; the controller's job is to validate parity on SD read (defense in depth — see § Header Format above) and pass through.
+For Modes 2 and 3 (pre-formatted blocks loaded from `.pat` on SD), the controller transmits panel blocks **without modification**: enable chip-select for the panel, clock out the entire panel block (`header + command + pixels + duty_cycle`), repeat for all panels in the panel set, disable chip-select. Pre-formatted blocks eliminate per-frame parity calculation; the controller's job is to validate parity on SD read (defense in depth — see § Header Format above) and pass through.
 
 For Modes 4, 5, and any synthesized panel block (all-on, all-off, error displays, ISP), the controller composes the block and recomputes parity before transmission.
 
@@ -171,7 +172,7 @@ The PC host (MATLAB / Python / web) generates pattern files:
    - Compute parity per G6 Panel Protocol v1.
    - Insert header byte (`0x01` or `0x81`) and command byte (`0x10` GS2 / `0x30` GS16).
    - Pack pixels per G6 panel format (row-major, MSB-first, bottom-left origin; flip MATLAB row → panel row via `row_from_bottom = 19 - row`).
-   - Append stretch value.
+   - Append duty_cycle value.
 4. **Frame assembly**: prepend `"FR"` magic and frame index to panel blocks.
 5. **Checksum**: compute XOR over all frame data, store in header byte 17.
 6. **File writing**: 18-byte header followed by all frames.
@@ -185,12 +186,6 @@ Cross-reference: [`Generation 6/maDisplayTools/docs/patterns.md`](../../Generati
 In v2 the pattern header carries `row_count`, `col_count`, and the 6-byte panel mask. Region and SPI-bus assignment are looked up by Arena ID from the compiled-in [`g6_arena_configs.h`](g6_arena_configs.h) table; the pattern header carries no region/SPI-bus info.
 
 ---
-
-## Open Questions / TBDs
-
-1. **No G6 controller firmware exists.** All Controller Operation steps above are aspirational; G4.1 slim is a G4 baseline only. G6 controller scoping happens in [`g6_03-controller.md`](g6_03-controller.md).
-
-(Arena ID and Observer ID semantics are resolved by the [maDisplayTools arena registry](../../Generation%206/maDisplayTools/configs/arena_registry/README.md): both are 6-bit, per-generation namespaces. Arena ID: 1–10 lab / 11–50 community / 51–62 user / 63 reserved. Observer ID: 1–20 lab / 21–50 community / 51–62 user / 63 reserved. **Observer ID is host-side metadata only — the controller does not interpret it**; it identifies the observer perspective a pattern was rendered for, supporting one pattern × many perspectives in a library.)
 
 ## Cross-references
 

--- a/docs/development/g6_06-host-software.md
+++ b/docs/development/g6_06-host-software.md
@@ -13,7 +13,7 @@ This file captures the firmware-side perspective on host-PC software responsibil
 
 The host-side MATLAB tooling already exists and is partially G6-aware: `Generation 6/maDisplayTools/` (HEAD `a51fe18`) supplies `g6/g6_save_pattern.m` (writes the v2 18-byte pattern header) and `g6/g6_encode_panel.m` (encodes per-panel GS2/GS16 blocks), validated end-to-end against the JS encoder in `webDisplayTools` via the round-trip JSON test vectors at `g6/g6_encoding_reference.json`. The submodule's own docs (`Generation 6/maDisplayTools/docs/{g6_quickstart, sd_card_deployment_notes, experiment_pipeline_guide, pattern_library_convention, pattern_tools_quickstart, patterns}.md`) are authoritative for the actual MATLAB workflow today and are published in the public Jekyll site.
 
-**Deep host-side spec migration is explicitly deferred.** This file's role is to capture the firmware ↔ host contract — what data formats and command sequences the firmware assumes the host will produce — not to re-document maDisplayTools. The deferral applies until either (a) the maDisplayTools tooling itself migrates further toward G6 (e.g., adds a v3 trigger workflow, Mode 1 TSI authoring, or PSRAM-mode preload management), at which point this file expands; or (b) the controller doc (`g6_03`) surfaces a host-side requirement not yet built in maDisplayTools.
+**Deep host-side spec migration is explicitly deferred.** This file's role is to capture the firmware ↔ host contract — what data formats and command sequences the firmware assumes the host will produce — not to re-document maDisplayTools. The deferral applies until either (a) the maDisplayTools tooling itself migrates further toward G6 (e.g., adds a Triggered/Gated workflow, Mode 1 TSI authoring, or PSRAM-mode preload management), at which point this file expands; or (b) the controller doc (`g6_03`) surfaces a host-side requirement not yet built in maDisplayTools.
 
 **maDisplayTools v2 already supplies the firmware contract** for v1 patterns: 18-byte v2 pattern header (per [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md)), per-panel GS2/GS16 block encoding (per [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) v1 message format), and round-trip-validated cross-platform encoding via `g6_encoding_reference.json`. Host-side gaps still TBD are tracked under Open Questions.
 
@@ -95,7 +95,7 @@ v2 capability detection shares the v1 "G6 mode" gap above — same `get-controll
 
 - [Source Google Doc, "Host PC Matlab SW" tab](https://docs.google.com/document/d/17crYq4sdD1GhazOPS_Yi6UyGV6ugUy3WGnCWWw49r_0/edit#)
 - [`g6_00-architecture.md`](g6_00-architecture.md) — host/controller/panel responsibility split
-- [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) — panel protocol v1 + v2 + v3 + v4/v5 (the firmware that the host writes for)
+- [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) — panel protocol v1 + v2 + v3 (the firmware that the host writes for)
 - [`g6_02-led-mapping.md`](g6_02-led-mapping.md) — pixel ↔ LED designator mapping (host-side concern; firmware sees opaque payload)
 - [`g6_03-controller.md`](g6_03-controller.md) — controller-side firmware contracts (the other half of host ↔ firmware spec)
 - [`g6_04-pattern-file-format.md`](g6_04-pattern-file-format.md) — on-disk pattern file format (the canonical wire format between host and controller)

--- a/docs/development/g6_07-arena-firmware-interface.md
+++ b/docs/development/g6_07-arena-firmware-interface.md
@@ -1,7 +1,7 @@
 # G6 — Arena Firmware Interface
 
 Source: G6 panels protocol v1 proposal ([Google Doc `17crYq4s...`](https://docs.google.com/document/d/17crYq4sdD1GhazOPS_Yi6UyGV6ugUy3WGnCWWw49r_0/edit#), tab "G6 arena design (v1/v2)"). Hardware authority: [`reiserlab/LED-Display_G6_Hardware_Arena`](https://github.com/reiserlab/LED-Display_G6_Hardware_Arena) (first production run `v1.1.7`; design at `arena_10-10/arena_10-10_v1/production/v1p1r7/`).
-Status: **Thin firmware-interface reference with extracted pin assignments.** This file pulls only the firmware-relevant facts the controller doc ([`g6_03-controller.md`](g6_03-controller.md)) and the v3 trigger work need, plus a per-peripheral Teensy 4.1 pin table extracted from the KiCad schematics. Authoritative hardware documentation lives in the `Generation 6/Arena` submodule (`docs/arena.md`); do not duplicate hardware details here.
+Status: **Thin firmware-interface reference with extracted pin assignments.** This file pulls only the firmware-relevant facts the controller doc ([`g6_03-controller.md`](g6_03-controller.md)) and the Triggered/Gated EINT work need, plus a per-peripheral Teensy 4.1 pin table extracted from the KiCad schematics. Authoritative hardware documentation lives in the `Generation 6/Arena` submodule (`docs/arena.md`); do not duplicate hardware details here.
 
 ## Authoritative source
 
@@ -13,8 +13,6 @@ Status: **Thin firmware-interface reference with extracted pin assignments.** Th
   - `arena_10-10/arena_10-10_v1/assets/arena_10_of_10_v1r1.pdf` — schematic PDF rendered from the same sources
 
 - **Test arena (historical, dev-only, not used):** [`reiserlab/LED-Display_G6_Hardware_Test_Arena`](https://github.com/reiserlab/LED-Display_G6_Hardware_Test_Arena) (in this clone as the `Generation 6/Hardware` submodule). Per its own `docs/test-arena.md`: "intended as a development platform for arena firmware, but it was never actually used … this test arena should not be the default starting point". Captured here only because the dev-set README's status table lists it as a sibling of the production arena; firmware work targets the production arena, not the test arena.
-
-**💡 Note — version-mapping in the Arena submodule:** the production Arena `README.md` declares v1.1.7 as the current production run, but `docs/arena.md` still recommends v1p1r6 and the KiCad project root keeps a `_v1r1` filename across revisions. Out-of-band action item for the upstream Arena repo to reconcile; not a spec question for this dev set.
 
 ---
 
@@ -137,7 +135,7 @@ The source spec calls out the AI line specifically for "flight arena experiments
 - The slim G4.1 controller had `gain_` stored but never read; closed loop ran on an internal counter, not a real analog input.
 - **Mode 4 wiring:** controller samples **AIN0** (Teensy D14, BNC J28, ±10 V via OPA2277 → 0–3.3 V at ADC) at **500 Hz**; computes `fps = AI_voltage × 100 × gain / 10` where `gain` from `trial-params` is a signed-int 10× scaling factor (typical `-20` = -2.0 fps/V matches G3 flight-arena behavior). AIN1 (D15, J29) unused for Mode 4 — available for experimenter use. Full spec in [`g6_03-controller.md`](g6_03-controller.md) § 6 Mode Behavior on G6.
 
-### v3 Triggered/Gated display relevance
+### Triggered/Gated display relevance
 
 The arena exposes three EINT-related signals — and one configurable jumper (**J30**) that determines whether the external trigger reaches the panels directly or is mediated by the Teensy:
 
@@ -145,26 +143,26 @@ The arena exposes three EINT-related signals — and one configurable jumper (**
 |---|---|---|---|
 | BNC **J3** ("External Interrupt" silk) | pin 29 / D37 | Bidirectional 5 V via SN74LVC1T45 (U2) | Teensy-only path. **No panel bypass.** General-purpose interrupt the controller can monitor or assert. |
 | BNC **J4** ("0-5V Digital In/Out" silk) | pin 27 / D35 | Bidirectional 5 V via SN74LVC1T45 (U3) | Doubles as the panel-trigger source via jumper J30. The "DIO" silk label understates this. |
-| Panel-internal `TNY.EINT` | pin 25 / D33 | Driven via R25 (33 Ω) into the EINT fan-out for all 10 panel columns | Controller-driven path to fire (Triggered) or window-gate (Gated) the panels' display in v3 operation. |
+| Panel-internal `TNY.EINT` | pin 25 / D33 | Driven via R25 (33 Ω) into the EINT fan-out for all 10 panel columns | Controller-driven path to fire (Triggered) or window-gate (Gated) the panels' display. |
 | **Jumper J30** (selector) | — | Connects `D35_0_3V3` (J4 input at 3.3 V) to `TNY.EINT` via R216 (1 kΩ) | **Shorted = direct path**: J4 BNC drives panels with no Teensy in the loop. **Open = Teensy-mediated**: firmware reads D35 input and explicitly drives D33 output to forward. |
 
-For v3 trigger work this means **two distinct deployment modes** are physically supported:
+For Triggered/Gated work this means **two distinct deployment modes** are physically supported:
 
-- **Direct trigger (J30 shorted)** — lowest-latency external triggering/gating. Useful when the experiment-side trigger waveform is already correctly shaped for v3 Triggered or Gated mode (edge polarity, pulse width, window timing). The Teensy can still observe the signal on D35, but firmware participation is optional.
-- **Teensy-mediated trigger (J30 open)** — highest flexibility. Firmware can perform timing reshape, debouncing, edge-polarity inversion, gating-window enforcement, sync-to-BCM-cycle alignment, or skip entirely (firmware decides whether to forward). Required if the experiment-side trigger doesn't directly match the panel-protocol v3 expectations.
+- **Direct trigger (J30 shorted)** — lowest-latency external triggering/gating. Useful when the experiment-side trigger waveform is already correctly shaped for Triggered or Gated mode (edge polarity, pulse width, window timing). The Teensy can still observe the signal on D35, but firmware participation is optional.
+- **Teensy-mediated trigger (J30 open)** — highest flexibility. Firmware can perform timing reshape, debouncing, edge-polarity inversion, gating-window enforcement, sync-to-BCM-cycle alignment, or skip entirely (firmware decides whether to forward). Required if the experiment-side trigger doesn't directly match the panel-protocol Triggered/Gated expectations.
 
 Cross-references:
 
-- [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § v3 documents the panel-side Triggered (per-edge single-shot, `0x12`/`0x32`/`0x52`) and Gated (window gating, `0x14`/`0x34`/`0x54`) modes plus two open issues (trigger edge polarity, sync-vs-async gating semantics) — both decisions are easier to manage in **J30-open** mode where firmware can reshape the trigger.
-- The slim G4.1 controller has no input pins beyond CS lines; v3 trigger wiring is **net-new for G6** and depends on these arena EINT lines.
+- [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § `0x12` / `0x13` documents the panel-side Triggered (per-edge single-shot — v1 `0x12` 2L, `0x32` 16L; v2 `0x52` PSRAM) and Gated (output-enable gate — v1 `0x13` 2L, `0x33` 16L; v2 `0x53` PSRAM) modes plus open issues on trigger edge polarity — easier to manage in **J30-open** mode where firmware can reshape the trigger.
+- The slim G4.1 controller has no input pins beyond CS lines; EINT trigger wiring (used by v1 Triggered/Gated) is **net-new for G6** and depends on these arena EINT lines.
 
-**J30 default = OPEN.** Shipped arenas leave J30 open by default → Teensy-mediated EINT path is the canonical v3 wiring. Direct-trigger mode (J30 shorted) is a deliberate per-experiment opt-in documented in arena bring-up notes. Firmware cannot detect the position, so the assumed-open default must be verified physically per arena.
+**J30 default = OPEN.** Shipped arenas leave J30 open by default → Teensy-mediated EINT path is the canonical wiring. Direct-trigger mode (J30 shorted) is a deliberate per-experiment opt-in documented in arena bring-up notes. Firmware cannot detect the position, so the assumed-open default must be verified physically per arena.
 
 ### v2 PSRAM / Mode 1 (TSI DO/AO) relevance
 
 The source spec for Mode 1 TSI files defines a 5-byte record `[FrameIndex16, DO, AO_lo, AO_hi]` with both DO and AO output lines' pin assignments noted as "depending on arena design". Reconciled:
 
-- The arena exposes **1 AO** (MCP4725 over I²C, 0–5 V, BNC J27) and **1 DO** (Teensy D35, level-translated to 5 V, BNC J4 — bidirectional, configured as output for Mode 1). **Caveat:** if jumper J30 is shorted, every Mode 1 DO toggle on D35 also retriggers the panel EINT bus via R216. To use D35 as an experimenter DO output without disturbing v3 gating, J30 must be left open. Firmware cannot detect this conflict.
+- The arena exposes **1 AO** (MCP4725 over I²C, 0–5 V, BNC J27) and **1 DO** (Teensy D35, level-translated to 5 V, BNC J4 — bidirectional, configured as output for Mode 1). **Caveat:** if jumper J30 is shorted, every Mode 1 DO toggle on D35 also retriggers the panel EINT bus via R216. To use D35 as an experimenter DO output without disturbing Gated-mode display, J30 must be left open. Firmware cannot detect this conflict.
 - The TSI record's DO byte (1 byte) → encodes a single digital output state; arena has 1 DO line → straightforward mapping.
 - The TSI record's AO field (16 bits) → encodes a single analog output sample; arena has 1 AO line → single-channel; firmware writes the upper 12 bits to MCP4725 (DAC is 12-bit, low 4 bits of AO field are ignored or rounded).
 - **The source spec floated "2 AO lines might be interesting, depending on arena design".** As-built has 1 AO — adding a second would require an arena re-spin (or repurposing one of the AI lines, which the OPA2277 chain doesn't currently support).
@@ -197,6 +195,6 @@ The source spec for Mode 1 TSI files defines a 5-byte record `[FrameIndex16, DO,
 - [reiserlab/LED-Display_G6_Hardware_Arena](https://github.com/reiserlab/LED-Display_G6_Hardware_Arena) — production arena submodule remote (used to populate this doc via `gh api`)
 - [reiserlab/LED-Display_G6_Hardware_Test_Arena](https://github.com/reiserlab/LED-Display_G6_Hardware_Test_Arena) — historical/never-used dev test arena
 - [`g6_00-architecture.md`](g6_00-architecture.md) — host/controller/panel split; the arena hosts the controller
-- [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) — panel protocol; v3 trigger semantics interact with the EINT lines on this arena
-- [`g6_03-controller.md`](g6_03-controller.md) — controller doc; arena facts here resolve open questions about CS-line topology, AI source for Mode 4, EINT for v3 gating
+- [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) — panel protocol; Triggered/Gated semantics interact with the EINT lines on this arena
+- [`g6_03-controller.md`](g6_03-controller.md) — controller doc; arena facts here resolve open questions about CS-line topology, AI source for Mode 4, EINT for Gated-mode display
 - [`g6_06-host-software.md`](g6_06-host-software.md) — host-side concerns; arena geometry must be supplied from host since controller is geometry-ignorant

--- a/docs/development/g6_docs-open-issues.md
+++ b/docs/development/g6_docs-open-issues.md
@@ -8,11 +8,9 @@ Live `⚠ Flag` callouts and per-file `Open Questions / TBDs` sections inside ea
 
 ## Spec decisions still open
 
-- **v2/v3 superset compatibility: normative MUST or soft MAY?** `g6_01-panel-protocol.md` § v2 body says panels MUST accept all commands from versions 1 through N; the parenthetical that follows says scope may be narrowed during implementation review. Pick one. Recommendation: commit to MUST (matches what's prototyped) and drop the parenthetical. Deferred to design-review session.
-
 - **PSRAM index semantics + preload atomicity.** `g6_01` v2 uses "PSRAM index/location" without saying whether the 24-bit value is a byte address, frame slot, record index, or typed handle — plus bounds, alignment, GS2/GS16 type tagging, persistence across reset, full-memory behavior. Separately: if a preload pass is interrupted (one panel reboots mid-load), one panel can hold a different pattern table than its neighbors and the same 24-bit index then drives a spatially inconsistent stimulus. Needs a half-page subsection in `g6_01` § v2 once the address-space question is answered.
 
-## Deferred design pressure (Codex-surfaced, acknowledged but not closed)
+## Deferred design pressure (acknowledged but not closed)
 
 - **ISP-in-v1 vs separate protocol version.** Putting flash-write opcodes in v1 means every future v2/v3/v4 panel firmware must continue to support them. A dedicated ISP protocol with explicit `BOOT_TO_ISP` transition would isolate dangerous operations and survive version evolution. The ISP section is currently marked **"Draft — design-review needed"** with four flagged design holes (atomic staging, image authenticity, version-evolution, mixed-firmware-on-failure) — see [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § ISP open questions.
 

--- a/docs/development/g6_docs-open-issues.md
+++ b/docs/development/g6_docs-open-issues.md
@@ -20,7 +20,17 @@ Live `⚠ Flag` callouts and per-file `Open Questions / TBDs` sections inside ea
 
 - **Stale config names in `Generation 6/maDisplayTools/README.md`** (`G6_2x10_full`, `G6_2x8_walking` — don't match registered names `G6_2x10`, `G6_2x8of10`). Out-of-band item for the maDisplayTools submodule.
 
-- **Round-trip vector regeneration.** `Generation 6/maDisplayTools/g6/g6_encoding_reference.json` was generated against pre-fix MATLAB output. After the MATLAB parity + col_count fixes, regenerate against the corrected encoder and confirm JS+MATLAB agree byte-for-byte.
+## Follow-up after CRC spec lands
+
+The dev-set specifies CRC-8/AUTOSAR for wire-level slots (CIPO confirmation, ISP extended confirmation, pattern-file header byte 17 over bytes 0-16) and CRC-16/CCITT for per-frame integrity in pattern files. Downstream work:
+
+- **Firmware swap in `reiserlab/LED-Display_G6_Firmware_Panel @ feat/v1-stage2-bcm`** — `Message::calculate_8bit_checksum()` body changes from sum-mod-256 to CRC-8/AUTOSAR (256-byte LUT, table-driven). Consider renaming `calculate_crc8()`. Stacked-panel bench-test re-baseline follows.
+- **MATLAB encoder update** in `Generation 6/maDisplayTools/g6/g6_save_pattern.m` — (a) swap header byte 17 from byte-wise XOR over all frame data to CRC-8/AUTOSAR over header bytes 0-16; (b) append per-frame CRC-16/CCITT trailer to each frame.
+- **JS encoder update** in `Generation 6/webDisplayTools/` — same two changes.
+- **Pattern-file consumers** (any reader code in maDisplayTools/webDisplayTools/controller) — update file_size and frame_size formulas to account for the per-frame +2 bytes.
+- **v2 short-command padding** — when v2 firmware lands, ensure `0x0F` Reset PSRAM, `0x02` Query diagnostics, `0x03` Reset diagnostic stats are all sent with 1 reserved padding byte (per [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § Confirmation message ≥ 3-byte rule). Already reflected in the v2 spec command definitions.
+- **Round-trip vector regeneration.** `Generation 6/maDisplayTools/g6/g6_encoding_reference.json` regenerated against the corrected encoders; pin protocol-specific CRC-8 vectors (`01 10 00…00 00` → `0xC6`, `81 30 00…00 00` → `0x0C`, COMM_CHECK canonical → `0x8B`) and per-frame CRC-16 vectors. Confirm MATLAB↔JS byte-for-byte. Also subsumes the existing post-fix regen item.
+- **Sharp-cite re-add** — once firmware lands `calculate_crc8()` and the controller adds `verify_crc16()` for per-frame validation, add `file:line` cites from `g6_01` § Confirmation message and `g6_04` § Per-frame CRC-16 (CLAUDE.md rule #9).
 
 ## Out-of-band
 

--- a/docs/development/g6_docs-open-issues.md
+++ b/docs/development/g6_docs-open-issues.md
@@ -29,7 +29,7 @@ The dev-set specifies CRC-8/AUTOSAR for wire-level slots (CIPO confirmation, ISP
 - **JS encoder update** in `Generation 6/webDisplayTools/` — same two changes.
 - **Pattern-file consumers** (any reader code in maDisplayTools/webDisplayTools/controller) — update file_size and frame_size formulas to account for the per-frame +2 bytes.
 - **v2 short-command padding** — when v2 firmware lands, ensure `0x0F` Reset PSRAM, `0x02` Query diagnostics, `0x03` Reset diagnostic stats are all sent with 1 reserved padding byte (per [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § Confirmation message ≥ 3-byte rule). Already reflected in the v2 spec command definitions.
-- **Round-trip vector regeneration.** `Generation 6/maDisplayTools/g6/g6_encoding_reference.json` regenerated against the corrected encoders; pin protocol-specific CRC-8 vectors (`01 10 00…00 00` → `0xC6`, `81 30 00…00 00` → `0x0C`, COMM_CHECK canonical → `0x8B`) and per-frame CRC-16 vectors. Confirm MATLAB↔JS byte-for-byte. Also subsumes the existing post-fix regen item.
+- **Round-trip vector regeneration.** `Generation 6/maDisplayTools/g6/g6_encoding_reference.json` regenerated against the corrected encoders; pin protocol-specific CRC-8 vectors (`01 10 00…00 00` → `0xC6`, `01 30 00…00 00` → `0x6D`, COMM_CHECK canonical → `0x8B`) and per-frame CRC-16 vectors. Confirm MATLAB↔JS byte-for-byte. Also subsumes the existing post-fix regen item.
 - **Sharp-cite re-add** — once firmware lands `calculate_crc8()` and the controller adds `verify_crc16()` for per-frame validation, add `file:line` cites from `g6_01` § Confirmation message and `g6_04` § Per-frame CRC-16 (CLAUDE.md rule #9).
 
 ## Out-of-band


### PR DESCRIPTION
## Summary

- Lands the V1/V2/V3 feature-class restructure as canonical in `g6_01-panel-protocol.md` (v1 = live SPI display, v2 = PSRAM-backed, v3 = everything-else; v4/v5 namespaces dissolved). Bulk of `g6_01` diff is the in-flight rewrite from the prior session that was never committed.
- Reconciles `g6_03-controller.md`, `g6_07-arena-firmware-interface.md`, `g6_06-host-software.md` against the new themes: Triggered/Gated are v1 (not v3); wrong Gated opcodes `0x14`/`0x34`/`0x54` corrected to `0x13`/`0x33`/`0x53`; v4 references retargeted to v3 predefined-pattern flash (`0x7x`).
- Paper-trail / archeology pruning across the whole dev set per CLAUDE.md doc philosophy: deletes "Historical context (v0.1)" in `g6_02`, "Recently resolved" in open-issues, "(aspirational)" hedges in `g6_04`, source-spec restructure parentheticals in `g6_00`, v4/v5 evolution sub-bullets in `g6_01`, archeology framing in `g6_03` (reconciliation tables themselves retained per user scope).

## Merge gate

Per the dev-set handoff: **do not merge until v1 firmware stacked-panel bench-test passes.** This PR is for Frank's review of the spec rollup; the merge to `main` is held pending hardware verification.

## Test plan

- [ ] Frank confirms protocol-restructure decisions match his understanding (V1/V2/V3 themes, Triggered/Gated opcodes, Persistent already-v1).
- [ ] Spot-check that no remaining doc references the dissolved `0x14`/`0x34`/`0x54` Gated opcodes or the dissolved v4/v5 namespaces.
- [ ] Verify `g6_03` controller-scope rewrite reads coherently end-to-end (the largest substantive change).
- [ ] Hold merge pending v1 panel firmware stacked-panel bench-test on `reiserlab/LED-Display_G6_Firmware_Panel @ feat/v1-stage2-bcm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)