### PR TITLE
docs(g6 dev): post-CRC-merge spec hygiene

### DIFF
--- a/docs/development/g6_01-panel-protocol.md
+++ b/docs/development/g6_01-panel-protocol.md
@@ -710,7 +710,7 @@ v1 panel firmware: [`reiserlab/LED-Display_G6_Firmware_Panel`](https://github.co
 
 | Spec item | Status |
 | :-- | :-- |
-| Message framing, header byte, parity rule, CIPO 3-byte confirmation slot (4-state encoding, `0xFF` COMM_CHECK-fail sentinel) | **CIPO checksum: CRC-8/AUTOSAR (firmware update pending).** Other framing items: implemented, not yet stacked-panel bench-validated. |
+| Message framing, header byte, parity rule, CIPO 3-byte confirmation slot (4-state encoding, `0xFF` COMM_CHECK-fail sentinel) | CIPO checksum: CRC-8/AUTOSAR implemented ([`Message::calculate_crc8`](https://github.com/reiserlab/LED-Display_G6_Firmware_Panel/blob/main/panel/src/message.cpp#L243-L251), 256-byte LUT at [L215–L241](https://github.com/reiserlab/LED-Display_G6_Firmware_Panel/blob/main/panel/src/message.cpp#L215-L241)). Other framing items: implemented, single-panel-verified on v0.3.1 hardware (clean boot, 60 s selftest cycle, no PIO IRQ timeouts; ~30 mA idle → ~320 mA all-on @ duty_cycle=255 from MacBook USB-C). Not yet stacked-panel bench-validated. |
 | `0x01` COMM_CHECK (byte-for-byte validation against canonical payload) | implemented |
 | `0x10` / `0x11` 2L Oneshot + Persistent, `0x30` / `0x31` 16L Oneshot + Persistent | implemented |
 | Duty cycle (BCM-via-PIO with fixed-period scan, default 1 kHz refresh) | implemented |

--- a/docs/development/g6_docs-open-issues.md
+++ b/docs/development/g6_docs-open-issues.md
@@ -16,21 +16,16 @@ Live `⚠ Flag` callouts and per-file `Open Questions / TBDs` sections inside ea
 
 - **`g6_arena_configs.h` static-const-in-header.** Multiple TUs `#include`ing the header each get their own copy of the arena table. Codegen emits the same pattern; cleanest fix is to split codegen output into `.h` (extern decls) + `.c` (definitions). Deferred to a follow-up codegen pass.
 
-- **Host vs controller parity ownership contradiction** between `g6_03-controller.md` § Modify-for-G6 ("controller adds parity") and `g6_04-pattern-file-format.md` § Transmission ("host pre-computes parity; controller transmits raw"). Pre-existing in the dev set.
-
 - **Stale config names in `Generation 6/maDisplayTools/README.md`** (`G6_2x10_full`, `G6_2x8_walking` — don't match registered names `G6_2x10`, `G6_2x8of10`). Out-of-band item for the maDisplayTools submodule.
 
 ## Follow-up after CRC spec lands
 
-The dev-set specifies CRC-8/AUTOSAR for wire-level slots (CIPO confirmation, ISP extended confirmation, pattern-file header byte 17 over bytes 0-16) and CRC-16/CCITT for per-frame integrity in pattern files. Downstream work:
+CRC-8/AUTOSAR for wire-level slots (CIPO confirmation, ISP extended confirmation, pattern-file header byte 17) and CRC-16/CCITT-FALSE for per-frame integrity in pattern files. Status:
 
-- **Firmware swap in `reiserlab/LED-Display_G6_Firmware_Panel @ feat/v1-stage2-bcm`** — `Message::calculate_8bit_checksum()` body changes from sum-mod-256 to CRC-8/AUTOSAR (256-byte LUT, table-driven). Consider renaming `calculate_crc8()`. Stacked-panel bench-test re-baseline follows.
-- **MATLAB encoder update** in `Generation 6/maDisplayTools/g6/g6_save_pattern.m` — (a) swap header byte 17 from byte-wise XOR over all frame data to CRC-8/AUTOSAR over header bytes 0-16; (b) append per-frame CRC-16/CCITT trailer to each frame.
-- **JS encoder update** in `Generation 6/webDisplayTools/` — same two changes.
-- **Pattern-file consumers** (any reader code in maDisplayTools/webDisplayTools/controller) — update file_size and frame_size formulas to account for the per-frame +2 bytes.
-- **v2 short-command padding** — when v2 firmware lands, ensure `0x0F` Reset PSRAM, `0x02` Query diagnostics, `0x03` Reset diagnostic stats are all sent with 1 reserved padding byte (per [`g6_01-panel-protocol.md`](g6_01-panel-protocol.md) § Confirmation message ≥ 3-byte rule). Already reflected in the v2 spec command definitions.
-- **Round-trip vector regeneration.** `Generation 6/maDisplayTools/g6/g6_encoding_reference.json` regenerated against the corrected encoders; pin protocol-specific CRC-8 vectors (`01 10 00…00 00` → `0xC6`, `01 30 00…00 00` → `0x6D`, COMM_CHECK canonical → `0x8B`) and per-frame CRC-16 vectors. Confirm MATLAB↔JS byte-for-byte. Also subsumes the existing post-fix regen item.
-- **Sharp-cite re-add** — once firmware lands `calculate_crc8()` and the controller adds `verify_crc16()` for per-frame validation, add `file:line` cites from `g6_01` § Confirmation message and `g6_04` § Per-frame CRC-16 (CLAUDE.md rule #9).
+- **Panel firmware:** ✓ landed (`reiserlab/LED-Display_G6_Firmware_Panel` commit `7594dbd`; single-panel smoke-tested on v0.3.1; sharp `file:line` cite to `Message::calculate_crc8` now in `g6_01` § Implementation status).
+- **v2 short-command padding** (`0x0F`, `0x02`, `0x03` carry 1 reserved byte): ✓ already in v2 spec command definitions.
+- **MATLAB + JS encoders, pattern-file readers, `g6_encoding_reference.json` regen:** pending; tracked in a private session handoff. Covers `g6_save_pattern.m` header byte 17 (XOR → CRC-8/AUTOSAR over bytes 0–16), per-frame CRC-16/CCITT-FALSE trailer (+2 B/frame), reader `frame_size` formula update, and MATLAB↔JS byte-equivalence pin against the corrected vectors (`0xC6`, `0x6D`, `0x8B`).
+- **Controller-side CRC-16 per-frame validation** (`verify_crc16()` or equivalent) and sharp `file:line` cite to it from `g6_04` § Per-frame CRC-16 — pending the G6 controller port.
 
 ## Out-of-band
 


### PR DESCRIPTION
## Summary

Three small post-merge cleanups now that firmware PR #1 (`reiserlab/LED-Display_G6_Firmware_Panel`) has landed:

1. **`g6_01` § Implementation status row flipped** — "CIPO checksum: CRC-8/AUTOSAR (firmware update pending)" → "implemented" with sharp `file:line` cite to `Message::calculate_crc8`. Also notes single-panel verification on v0.3.1 with bench current measurements (~30 mA idle → ~320 mA all-on, MacBook USB-C).

2. **Stale "parity ownership contradiction" line removed** from `g6_docs-open-issues.md`. The contradiction no longer exists: `g6_03` § Modify-for-G6 (line 47) and `g6_04` § Panel Block Format (lines 117–120) already describe the same rule — host pre-computes for SD-stored pattern files, controller recomputes for runtime-synthesized blocks (Modes 4/5, all-on, all-off, error displays, ISP). Stale tracking entry only; no spec text needed changing.

3. **§ Follow-up after CRC spec lands compressed** to current status:
   - Panel firmware: ✓ landed
   - v2 short-command padding: ✓ already in spec
   - MATLAB + JS encoders + readers + JSON regen: pending, in private session handoff
   - Controller-side CRC-16 validation: pending G6 controller port

Net diff: +6 / -11.

## Test plan

- [x] Diff inspected; no spec content removed, only stale tracking pruned
- [x] Sharp cite verified against `LED-Display_G6_Firmware_Panel @ main`: `Message::calculate_crc8` at `panel/src/message.cpp:243-251`, LUT at `:215-241`
- [x] Parity-ownership claim verified by reading `g6_03:47` + `g6_04:117-120` — both already aligned